### PR TITLE
Standardification with standard levels

### DIFF
--- a/docs/alert-center.md
+++ b/docs/alert-center.md
@@ -1,58 +1,69 @@
-# Proposal for Alert Center
+# Alert Center
 
 ## Alert Center Purpose
 
-The security alert center will provide sso-dashboard users security, information, and configuration alerts.
-Based on alert severity alerts should be called out differently based on category.  Different types of alerts
-will have different things the user can do with them.
+The security alert center will inform users of the sso-dashboard users with information about their security posture, important changes, etc.
+Security alerts are categorized by risk levels as defined in the [Standard Levels](https://wiki.mozilla.org/Security/Standard_Levels)
 
-### Alert Severity
+### What is an alert
 
-- __Information__ : an informational alert regarding systems maintenance or other information pertaining to apps in the dashboard.
+An alert is a small notification message for the user, which is meant to alert the user of an event. The alert is not necessarily security-relevant.
+The alert may be purely informational, or be acted upon (such as with "confirm, ask for help, alert someone" buttons).
+It is also important to understand the alert may not always been seen by the user.
 
-- __Warning__ : a warning regarding the state of the users account or configuration.  Example: ( Firefox is out of date, your password is older than (x) days)
+### Alert risk level
 
-- __High Security__ : a high security alert.  This is any event that would potentially create risk to Mozilla based on the state of the users
-account.  Example: ( Your version of Firefox is no longer supported or vulnerable.  Your account has been part of a major data breach. )
+The alert risk levels are standardized and defined at [Standard Levels](https://wiki.mozilla.org/Security/Standard_Levels) 
 
-- __High Security Alert__ ( from MozDef ):  MozDef the Mozilla defense platform tracks user account activity.  Alerts coming from MozDef tell
-the user that something anomalous happened with their account.  These are the category of alert that would require a user to self identify
-that the alert was a false positive or ask for help.  
+This is a summary for convenience (refer to the above link for up-to-date 'official' information and complete definitions).
+
+- __UNKNOWN risk (white `#ffffff`)__: Most likely to be unused in this context.
+- __LOW risk (grey `#cccccc`)__: Most likely to be unused in this context.
+- __MEDIUM risk (blue `#4a6785`)__: There could be a problem, attention is expected from the user. Ex: "You have logged in from a new location".
+- __HIGH risk (yellow `#ffd351`)__: There is a problem and it looks bad. User interaction required. Ex: "Your user logged in on a new system. Was it really you?".
+- __MAXIMUM risk (red `#d04437`)__: We're probably trying to call you on the phone right now, and find your physical whereabouts.  Ex: "We know for a fact that your service is compromised".
+
+__NOTE__: It is possible to add alerts that are not risk related but instead purely information for UX reasons. All security alerts must use the standard risk levels.
 
 ### Alert Schema
 
-As an enterprise infosec system I can send an alert for "All Users" or an individual and it should show in real time in the related user(s) dashboard.
+As an enterprise infosec service (machine/software) I can send an alert for "All Users" or an individual and it should show the alert in near real time in the related user(s) dashboard.
 
 ```
 alert:
-  severity: information|warning|high|mozdef  # Required
-  message: "Your just moved faster than superman." # Required
-  additonal_info: "A large amount of information that may be about what has happened." # Optional Displays only in alert center.
-  date: 07:07:07 6/26/17 GMT -8 # Optional
-  additional_label: "More Info" # Text rendered on button next to alert ( Optional )
-  additional_link: "https://wiki.example.com/geolocation/alert" # Optional
+  risk: unknown|low|medium|high|maximum  # Required: How important the alert is. Unknown and low risk alerts may not have a button displayed with the alert.
+  summary: "Your just moved faster than superman." # Required: The alert.
+  description: "A large amount of information that may be about what has happened." # Optional: Additional information about the alert.
+  date: 07:07:07 6/26/17 GMT -8 # Optional: date and time at which the alert event occured.
+  url: "https://wiki.example.com/geolocation/alert" # Optional: an URL rendered on a button next to the alert.
+  url_title: "More Info" # Optional: If an URL is set, this is the URL title.
 ```
 
-### Alert UI
+### Alert UI (notification bar)
 
-Information and warning alerts can only be acknowledged or dismissed.  They may also have a "more_info" link that takes them away from the dashboard.  
-
-__Informational alerts__
+Unknown and low risk alerts may not have a risk level indicator associated. These may be informational messages that do not carry any perceived risk.
+__Unknown and low risk alerts__
 !['dashboard.png'](images/warning.png)
 
-MozDef alerts should always be acknowledged as false positives or positives.  These are high severity use cases where infosec needs to be notified if the user needs help.  
 
-> A user flagging an alert as a false positive should require them to 2FA again to prevent an attacker from stealing a session etc and clearing their own alerts.  
+Medium, high and maximum risk alerts have buttons to acknowledge them as false-positive or to request help. If the alert is acknolwedged as false-positive, a 2FA prompt must be validated before continuing. This makes it more difficult for someone with access to the user session to flag alerts as false-positive.
 
-__MozDef Alerts__
+> The labeling, colors, etc. is to be updated in the example below.
+
+__Medium, high and maximum risk alerts__
 !['dashboard.png'](images/mozdef.png)
 
 ### Alert Center
 
-The alert center has all of the same information available as in the bar with additional information taken from the "additional info" about the alert.  Users can acknowledge / dismiss for all alerts not generated by MozDef and Confirm in the same way for MozDef alerts.  
+The alert center possess the same information available as the notification bar with additional information taken from the "description" field of the alert schema.
+Users can acknowledge false-positives or dismiss all alerts from the alert center as well. It also shows an history of recent alert notifications.
 
-## What about lot's of alerts?  
+## Additional considerations
 
-We probably also want to account for a user having a ton of alerts all at once.  Let's say that as a user I am part of a major data breach, my house gets robbed, and attackers are logging in with one of my 2FA device(s) and password all over the globe.  There should also be a high severity dialogue that says.
+### Amount of alerts
 
-"You have 52 alerts waiting.  View notification center."  _or something like that_ 
+We want to account for a user having a lot of alerts all at once.
+Let's say that as a user I am part of a major data breach, my house gets robbed, and attackers are logging in with one of my 2FA device(s) and password all over the globe.
+Instead of spamming the user, there should be a single dialog aggregating all alerts, such as:
+
+"Important: You have 52 high and maximum risk alerts. View notification center."  _or something like that_ 

--- a/docs/alert-center.md
+++ b/docs/alert-center.md
@@ -17,17 +17,17 @@ The alert risk levels are standardized and defined at [Standard Levels](https://
 
 This is a summary for convenience (refer to the above link for up-to-date 'official' information and complete definitions).
 
-- __UNKNOWN risk (white `#ffffff`)__: Most likely to be unused in this context.
-- __LOW risk (grey `#cccccc`)__: Most likely to be unused in this context.
-- __MEDIUM risk (blue `#4a6785`)__: There could be a problem, attention is expected from the user. Ex: "You have logged in from a new location".
-- __HIGH risk (yellow `#ffd351`)__: There is a problem and it looks bad. User interaction required. Ex: "Your user logged in on a new system. Was it really you?".
-- __MAXIMUM risk (red `#d04437`)__: We're probably trying to call you on the phone right now, and find your physical whereabouts.  Ex: "We know for a fact that your service is compromised".
+- __UNKNOWN risk (white ![#ffffff](https://placehold.it/15/ffffff/000000?text=+) `#ffffff`)__: Most likely to be unused in this context.
+- __LOW risk (grey ![#cccccc](https://placehold.it/15/cccccc/000000?text=+) `#cccccc`)__: Most likely to be unused in this context.
+- __MEDIUM risk (blue ![#4a6785](https://placehold.it/15/4a6785/000000?text=+)`#4a6785`)__: There could be a problem, attention is expected from the user. Ex: "You have logged in from a new location".
+- __HIGH risk (yellow ![#ffd351](https://placehold.it/15/ffd351/000000?text=+) `#ffd351`)__: There is a problem and it looks bad. User interaction required. Ex: "Your user logged in on a new system. Was it really you?".
+- __MAXIMUM risk (red ![#d04437](https://placehold.it/15/d04437/000000?text=+) `#d04437`)__: We're probably trying to call you on the phone right now, and find your physical whereabouts.  Ex: "We know for a fact that your service is compromised".
 
 __NOTE__: It is possible to add alerts that are not risk related but instead purely information for UX reasons. All security alerts must use the standard risk levels.
 
 ### Alert Schema
 
-As an enterprise infosec service (machine/software) I can send an alert for "All Users" or an individual and it should show the alert in near real time in the related user(s) dashboard.
+> As an enterprise infosec service (machine/software) I can send an alert for "All Users" or an individual and it should show the alert in near real time in the related user(s) dashboard.
 
 ```
 alert:
@@ -42,6 +42,7 @@ alert:
 ### Alert UI (notification bar)
 
 Unknown and low risk alerts may not have a risk level indicator associated. These may be informational messages that do not carry any perceived risk.
+
 __Unknown and low risk alerts__
 !['dashboard.png'](images/warning.png)
 
@@ -55,7 +56,7 @@ __Medium, high and maximum risk alerts__
 
 ### Alert Center
 
-The alert center possess the same information available as the notification bar with additional information taken from the "description" field of the alert schema.
+The alert center possess the same information available as the notification bar with additional information taken from the `description` field of the alert schema.
 Users can acknowledge false-positives or dismiss all alerts from the alert center as well. It also shows an history of recent alert notifications.
 
 ## Additional considerations
@@ -66,4 +67,4 @@ We want to account for a user having a lot of alerts all at once.
 Let's say that as a user I am part of a major data breach, my house gets robbed, and attackers are logging in with one of my 2FA device(s) and password all over the globe.
 Instead of spamming the user, there should be a single dialog aggregating all alerts, such as:
 
-"Important: You have 52 high and maximum risk alerts. View notification center."  _or something like that_ 
+> Important: You have 52 high and maximum risk alerts. View notification center.  _or something like that_ 

--- a/docs/alert-center.md
+++ b/docs/alert-center.md
@@ -8,12 +8,17 @@ Security alerts are categorized by risk levels as defined in the [Standard Level
 ### What is an alert
 
 An alert is a small notification message for the user, which is meant to alert the user of an event. The alert is not necessarily security-relevant.
-The alert may be purely informational, or be acted upon (such as with "confirm, ask for help, alert someone" buttons).
+The alert may be purely informational, or be acted upon:
+
+- Confirm: ***This was me***
+- Confirm and remember: ***This was me, don't bug me again for this***
+- Get help and alert: ***This wasn't me, I need help***
+
 It is also important to understand the alert may not always been seen by the user.
 
 ### Alert risk level
 
-The alert risk levels are standardized and defined at [Standard Levels](https://wiki.mozilla.org/Security/Standard_Levels) 
+The alert risk levels are standardized and defined by the [Standard Levels](https://wiki.mozilla.org/Security/Standard_Levels) 
 
 This is a summary for convenience (refer to the above link for up-to-date 'official' information and complete definitions).
 
@@ -23,7 +28,7 @@ This is a summary for convenience (refer to the above link for up-to-date 'offic
 - __HIGH risk (yellow ![#ffd351](https://placehold.it/15/ffd351/000000?text=+) `#ffd351`)__: There is a problem and it looks bad. User interaction required. Ex: "Your user logged in on a new system. Was it really you?".
 - __MAXIMUM risk (red ![#d04437](https://placehold.it/15/d04437/000000?text=+) `#d04437`)__: We're probably trying to call you on the phone right now, and find your physical whereabouts.  Ex: "We know for a fact that your service is compromised".
 
-__NOTE__: It is possible to add alerts that are not risk related but instead purely information for UX reasons. All security alerts must use the standard risk levels.
+__NOTE__: It is possible to add alerts that are not risk related but instead purely information for UX reasons. All security alerts **must** use the standard risk levels.
 
 ### Alert Schema
 
@@ -47,7 +52,7 @@ __Unknown and low risk alerts__
 !['dashboard.png'](images/warning.png)
 
 
-Medium, high and maximum risk alerts have buttons to acknowledge them as false-positive or to request help. If the alert is acknolwedged as false-positive, a 2FA prompt must be validated before continuing. This makes it more difficult for someone with access to the user session to flag alerts as false-positive.
+Medium, high and maximum risk alerts have buttons to acknowledge (and optionally remember the acknowledgement for this very type of alert) them as false-positive or to request help. If the alert is acknolwedged as false-positive, a 2FA prompt **must** be validated before continuing. This makes it more difficult for someone with access to the user session to flag alerts as false-positive.
 
 > The labeling, colors, etc. is to be updated in the example below.
 
@@ -68,3 +73,7 @@ Let's say that as a user I am part of a major data breach, my house gets robbed,
 Instead of spamming the user, there should be a single dialog aggregating all alerts, such as:
 
 > Important: You have 52 high and maximum risk alerts. View notification center.  _or something like that_ 
+
+### Remembering false-positives
+
+We should strive to eliminate false-positives in order to avoid user-fatigue. However, when a user asks for not being bothered again this could be a mistake. We should allow the user to cancel that action in the alert center, and/or also expire the "remember this false-positive" after a certain amount of time _such as 30 days_.


### PR DESCRIPTION
Feel free to squash the commits.
This follows the standard at https://wiki.mozilla.org/Security/Standard_Levels - but I've also added my grain of salt.

In particular note the addition of a "remember" button - I know this button was needed for such a system to be successful elsewhere.

Likewise, but did not add yet: we most likely want the users to be able to subscribe to alerts by email, sms, irc, slack in the future