### PR TITLE
Bug/cache control

### DIFF
--- a/ansible/nginx/start.sh
+++ b/ansible/nginx/start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-gunicorn app:app --worker-class gevent --bind 0.0.0.0:8000 &
+gunicorn app:app --worker-class gevent --bind 0.0.0.0:8000 --reload &
 nginx -c /etc/nginx/nginx.conf -g "daemon off;"

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -7,8 +7,8 @@ import mimetypes
 import os
 import watchtower
 
-from flask import (Flask, abort, render_template, jsonify, session, request, redirect,
-                   send_from_directory)
+from flask import (Flask, abort, render_template, jsonify, make_response, session,
+                   request, redirect, send_from_directory)
 from flask_assets import Environment, Bundle
 from flask_secure_headers.core import Secure_Headers
 from werkzeug.exceptions import BadRequest
@@ -310,7 +310,12 @@ def redirect_url():
             logger.info(
                 "Vanity URL found for {app}".format(app=match[vanity_url])
             )
-            return redirect(match[vanity_url], code=301)
+
+            resp = make_response(redirect(match[vanity_url], code=301))
+            resp.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'
+            resp.headers['Expires'] = '-1'
+
+            return resp
         else:
             pass
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,17 +1,17 @@
 import auth
 import config
-import datetime
-import hashlib
+
 import logging
 import mimetypes
 import os
+import vanity
 import watchtower
 
-from flask import (Flask, abort, render_template, jsonify, make_response, session,
+from flask import (Flask, abort, render_template, jsonify, session,
                    request, redirect, send_from_directory)
 from flask_assets import Environment, Bundle
 from flask_secure_headers.core import Secure_Headers
-from werkzeug.exceptions import BadRequest
+
 
 from user import User
 from alert import Alert
@@ -61,6 +61,7 @@ authentication = auth.OpenIDConnect(
 
 oidc = authentication.auth(app)
 
+vanity_router = vanity.Router(app=app).setup()
 # Add secure Headers to satify observatory checks
 
 sh = Secure_Headers()
@@ -250,87 +251,6 @@ def contribute_lower():
     }
 
     return jsonify(data)
-
-
-@app.route('/alert', methods=['POST'])
-@sh.wrapper()
-def publish_alert():
-    """
-    Takes JSON post with user e-mail to alert.
-    Minimum fields are email and message in the form
-    of a dict.
-
-    Example:
-        {
-          "user": {"email": "andrewkrug@gmail.com"},
-            "message": "this is a security alert"
-        }
-    """
-    try:
-        content = request.json
-        # Send a real time event to the user
-        m = hashlib.md5()
-        m.update(content['user']['email'])
-        channel = m.hexdigest()
-
-        sse.publish(
-            {"message": content['message']},
-            type="alert",
-            channel=channel
-        )
-
-        permanent_message = "Security Alert Logged at {date} : {message}".format(
-            date=datetime.datetime.now(),
-            message=content['message']
-        )
-        # Store the event in redis keyed to the users hashed e-mail
-
-        Alert().set(channel, permanent_message)
-
-        return jsonify({'status': 'success'})
-    except:
-        raise BadRequest('POST does not contain e-mail and message')
-        return jsonify({'status': 'fail'})
-
-
-vanity = Application().vanity_urls()
-logger.info("Vanity URLs loaded for {num} apps.".format(num=len(vanity)))
-logger.info(
-    "Count of apps by OP is {stats}".format(stats=Application().stats())
-)
-
-
-def redirect_url():
-    vanity_url = '/' + request.url.split('/')[3]
-
-    logger.info("Attempting to match {url}".format(url=vanity_url))
-
-    for match in vanity:
-        if match.keys()[0] == vanity_url:
-            logger.info(
-                "Vanity URL found for {app}".format(app=match[vanity_url])
-            )
-
-            resp = make_response(redirect(match[vanity_url], code=301))
-            resp.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'
-            resp.headers['Expires'] = '-1'
-
-            return resp
-        else:
-            pass
-
-    logger.info(
-        "Vanity URL could not be matched for {app}".format(app=vanity_url)
-    )
-
-
-for url in vanity:
-    try:
-        app.add_url_rule(url.keys()[0], url.keys()[0], redirect_url)
-        app.add_url_rule(url.keys()[0] + "/", url.keys()[0] + "/", redirect_url)
-    except Exception as e:
-        logger.error(e)
-        logger.info("Could not create vanity URL for {app}".format(app=url))
 
 if __name__ == '__main__':
     app.run()

--- a/dashboard/s3.py
+++ b/dashboard/s3.py
@@ -89,14 +89,25 @@ class AppFetcher(object):
         c.close()
         self.__update_etag(config['ETag'])
 
+    def __touch(self):
+        fname = 'app.py'
+        fhandle = open(fname, 'a')
+        try:
+            os.utime(fname, None)
+        finally:
+            fhandle.close()
+
     def sync_config_and_images(self):
         try:
             if self.is_updated():
                 print("Config file is updated fetching new config.")
                 self.__get_images()
                 self.__get_config()
+                # Touch app.py to force a gunicorn reload
+                self.__touch()
+                return True
             else:
-                pass
+                return False
                 # Do nothing
         except Exception as e:
             print(

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -77,17 +77,4 @@
   </div>
 {% endblock %}
 
-{% block extra_js %}
-  <!-- Temporarily removed until alert center comes online
-  <script>
-    var source = new EventSource("/stream?channel={{ user.userhash() }}");
-    source.addEventListener('alert', function(event) {
-        var data = JSON.parse(event.data);
-        $(".messages").append("<li class=\"security-alert\">" + " <div class=\"message\">" + "Security Alert Logged at " + (new Date().getHours()) + ":" + (new Date().getMinutes()) + " : " + data["message"] + "</div></li>");
-    }, false);
-    source.addEventListener('error', function(event) {
-        console.log("Failed to connect to event stream. Is Redis running?");
-    }, false);
-  </script>
-  -->
-{% endblock %}
+

--- a/dashboard/vanity.py
+++ b/dashboard/vanity.py
@@ -1,0 +1,27 @@
+from op import yaml_loader
+from flask import make_response, redirect, request
+
+class Router(object):
+    def __init__(self, app):
+        self.app = app
+        self.url_list = yaml_loader.Application().vanity_urls()
+
+    def setup(self):
+        for url in self.url_list:
+            try:
+                self.app.add_url_rule(url.keys()[0], url.keys()[0], self.redirect_url)
+                self.app.add_url_rule(url.keys()[0] + "/", url.keys()[0] + "/", self.redirect_url)
+            except Exception as e:
+                print(e)
+
+    def redirect_url(self):
+        vanity_url = '/' + request.url.split('/')[3]
+
+        for match in self.url_list:
+            if match.keys()[0] == vanity_url:
+                resp = make_response(redirect(match[vanity_url], code=301))
+                resp.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0'
+                resp.headers['Expires'] = '-1'
+                return resp
+            else:
+                pass


### PR DESCRIPTION
Adds a cache control header to all vanity_url redirects.  Currently set at do not cache for the period of time that we are migrating RPs to auth0.  Otherwise Chrome and Firefox will hold onto 301 redirects until the cache is cleared by the user.

Sample header post change:

```
HTTP/1.0 301 MOVED PERMANENTLY
Content-Type: text/html; charset=utf-8
Content-Length: 417
Location: https://auth.mozilla.auth0.com/samlp/smKTjsVVxUJDEkjIftOsP0bop2NWjysa?RelayState=https://mail.google.com/
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0
Expires: -1
Server: Werkzeug/0.12 Python/2.7.10
Date: Thu, 08 Jun 2017 15:44:39 GMT
```