### PR TITLE
Add media.mozillians.org to img-src CSP

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -88,6 +88,7 @@ sh.update(
             'img-src': [
                 'self',
                 'https://mozillians.org',
+                'https://media.mozillians.org',
                 'https://*.google-analytics.com'
             ],
             'font-src': [


### PR DESCRIPTION
We now serve Mozillians avatars from a different URL, so they aren't currently loading in the dashboard