### PR TITLE
hotfix for bug 1399778

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,6 +10,7 @@ phases:
       - cd ansible && ansible-container build --with-volumes ../:/dashboard
   post_build:
     commands:
+      - rm -rf /root/.docker/config.json
       - aws ecr get-login --region us-west-2 | bash
       - docker tag ansible-web ${DOCKER_REPO}:latest
       - docker push ${DOCKER_REPO}:latest


### PR DESCRIPTION
Users in the Taipei region and TPE1 office are unable to view the SSO dashboard after logging in

Some users with unicode chars in their profile can not log in.  This temporarily patches this.
 CHG0012101

