### PR TITLE
Fix Firefox 57 alert to align with new alerts design

### DIFF
--- a/dashboard/static/css/base.scss
+++ b/dashboard/static/css/base.scss
@@ -309,10 +309,12 @@ body {
             .alert-risk {
                 color: var(--alert-color);
                 background-color: var(--alert-bg-color);
-                padding: 5px 35px;
+                padding: 5px;
+                width: 140px;
                 text-transform: uppercase;
                 display: inline-block;
                 font-weight: bold;
+                text-align: center;
             }
         }
 

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -68,28 +68,33 @@
 
 {% block messages %}
   <div class="messages">
-    <div class="alert alert-medium" role="alert" id="alert-nightly">
-      <p><img src="/static/img/alerts/alert-white.svg" alt="alert-info">Want to help test Firefox? Give Firefox Beta a try!</p>
-      <div class="actions">
+    <div class="mui-row alert alert-low" role="alert" id="alert-nightly">
+      <div class="mui-col-md-3 alert-info">
+        <div class="alert-risk">low risk</div>
+      </div>
+      <div class="mui-col-md-6 alert-message">
+        <p>Want to help test Firefox? Give Firefox Beta a try!</p>
+      </div>
+      <div class="mui-col-md-3 alert-actions">
         <a href="https://beta.mozilla.org/" class="btn-alert" target="_blank"><img src="/static/img/alerts/arrow-right-white.svg" alt="alert-info"> Download</a>
         <span id="close-alert" class="closebtn">&times;</span>
       </div>
     </div>
 
     {% for alert in user.alerts %}
-    <div class="mui-row alert alert-{{ alert.risk }}" role="alert">
-      <div class="mui-col-md-3 alert-info">
-        <div class="alert-risk">{{ alert.risk }} risk</div>
+      <div class="mui-row alert alert-{{ alert.risk }}" role="alert">
+        <div class="mui-col-md-3 alert-info">
+          <div class="alert-risk">{{ alert.risk }} risk</div>
+        </div>
+        <div class="mui-col-md-6 alert-message">
+          <p>{{ alert.summary }}</p>
+        </div>
+        <div class="mui-col-md-3 alert-actions">
+          <a href="/notifications" class="btn-alert"><img src="/static/img/alerts/info-white.svg" alt="alert-info"> <span class="info-text">More Info</span></a>
+          <a href="{{ alert.url }}" class="btn-alert" target="_blank"><img src="/static/img/alerts/arrow-right-white.svg" alt="alert-info"> {{ alert.url_title }}</a>
+          <span id="submit-alert" class="closebtn" data-alert-id="{{ alert.get('alert_id') }}">&times;</span>
+        </div>
       </div>
-      <div class="mui-col-md-6 alert-message">
-        <p>{{ alert.summary }}</p>
-      </div>
-      <div class="mui-col-md-3 alert-actions">
-        <a href="/notifications" class="btn-alert"><img src="/static/img/alerts/info-white.svg" alt="alert-info"> <span class="info-text">More Info</span></a>
-        <a href="{{ alert.url }}" class="btn-alert" target="_blank"><img src="/static/img/alerts/arrow-right-white.svg" alt="alert-info"> {{ alert.url_title }}</a>
-        <span id="submit-alert" class="closebtn" data-alert-id="{{ alert.get('alert_id') }}">&times;</span>
-      </div>
-    </div>
     {% endfor %}
   </div>
 {% endblock %}


### PR DESCRIPTION
Relate issue: https://www.pivotaltracker.com/n/projects/2117111/stories/152397828

This aligns the temporary Firefox Beta alert with the recent changes on alerts UI.