### PR TITLE
Enrich error message page

### DIFF
--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -1,6 +1,12 @@
+import json
+import logging
+from josepy.jwk import JWK
+from josepy.jws import JWS
+
 """Class that governs all authentication with open id connect."""
 from flask_pyoidc.flask_pyoidc import OIDCAuthentication
 
+logger = logging.getLogger(__name__)
 
 class OpenIDConnect(object):
     """Auth object for login, logout, and response validation."""
@@ -54,3 +60,96 @@ class nullOpenIDConnect(OpenIDConnect):
             token_endpoint=None,
             userinfo_endpoint=None,
         )
+
+
+class tokenVerification(object):
+    def __init__(self, jws, public_key):
+        self.jws = jws
+        print(self.jws)
+        self.jws_data = {}
+        self.public_key = public_key
+        print(self.public_key)
+
+    @property
+    def verify(self):
+        return self._verified()
+
+    @property
+    def data(self):
+        self._verified()
+        return self.jws_data
+
+    @property
+    def error_code(self):
+        return self.jws_data.get('code')
+
+    @property
+    def preferred_connection_name(self):
+        return self.jws_data.get('preferred_connection_name')
+
+    @property
+    def redirect_uri(self):
+        self.jws_data.get('redirect_uri')
+
+    def _get_connection_name(self, connection):
+        CONNECTION_NAMES = {
+            'google-oauth2': 'Google',
+            'github': 'GitHub',
+            'Mozilla-LDAP-Dev': 'LDAP',
+            'Mozilla-LDAP': 'LDAP',
+            'email': 'passwordless email'
+        }
+        return (
+            CONNECTION_NAMES[connection]
+            if connection in CONNECTION_NAMES else connection
+        )
+
+    def _verified(self):
+        #try:
+        jwk = JWK.load(self.public_key)
+        self.jws = JWS.from_compact(self.jws)
+        print(self.jws)
+        #if self.jws.signature.combined.alg.name != 'RS256' or not self.jws.verify(jwk):
+        #    logger.warning('The public key signature was not valid for jws {jws}'.format(jws=self.jws))
+        #    print('fail')
+        #else:
+        #    self.jws_data = json.loads(self.jws.payload)
+        #    print(self.jws_data)
+        #    logger.info('Loaded JWS data.')
+        #    self.jws_data['connection_name'] = self._get_connection_name(data['connection_name'])
+        #    return True
+        #except Exception as e:
+        #    # logger.warning('JWS could not be decoded due to {error}'.format(error=e))
+        #    print(e)
+        #    return False
+
+    def error_message(self):
+        error_code = self.error_code
+        if error_code == 'githubrequiremfa':
+            error_text = \
+                "You must setup a security device(\"MFA\", \"2FA\") for your GitHub account in order to access\
+                this service.Please follow the\
+                <a href=\"https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/\">\
+                GitHub documentation\
+                </a> to setup your device, then try logging in again."
+        elif error_code == 'notingroup':
+            error_text = "Sorry, you do not have permission to access {client}.\
+            Please contact eus@mozilla.com if you should have access.".format(client=self.data.get('client'))
+        elif error_code == 'primarynotverified':
+            "You primary email address is not yet verified. Please verify your\
+            email address with {{ connection_name }} in order to use this service.".format(
+                connection_name=self.jws_data.get('connection_name')
+            )
+        elif error_code == 'incorrectaccount':
+            error_text = "Sorry, you may not login using {connection_name}.\
+             Please instead always login with {preferred_connection_name }.".format(
+                connection_name=self.jws_data.get('connection_name'),
+                preferred_connection_name=self.jws_data.get('preferred_connection_name')
+            )
+        else:
+            error_text = "Oye, something went wrong."
+
+        return error_text
+
+
+

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,4 +1,5 @@
 """Configuration loader for different environments."""
+import base64
 import os
 import watchtower
 
@@ -44,7 +45,9 @@ class DefaultConfig(object):
 
     CDN = 'https://cdn.{SERVER_NAME}'.format(SERVER_NAME=SERVER_NAME)
 
-    FORBIDDEN_PAGE_PUBLIC_KEY = get_secret('sso-dashboard.forbidden_page_public_key', {'app': 'sso-dashboard'})
+    FORBIDDEN_PAGE_PUBLIC_KEY = base64.b64decode(
+        get_secret('sso-dashboard.forbidden_page_public_key', {'app': 'sso-dashboard'})
+    )
 
 
 class ProductionConfig(DefaultConfig):

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -44,6 +44,8 @@ class DefaultConfig(object):
 
     CDN = 'https://cdn.{SERVER_NAME}'.format(SERVER_NAME=SERVER_NAME)
 
+    FORBIDDEN_PAGE_PUBLIC_KEY = get_secret('sso-dashboard.forbidden_page_public_key', {'app': 'sso-dashboard'})
+
 
 class ProductionConfig(DefaultConfig):
     PREFERRED_URL_SCHEME = 'https'

--- a/dashboard/templates/forbidden.html
+++ b/dashboard/templates/forbidden.html
@@ -10,8 +10,25 @@
       <div class="panel">
         <div class="pointer"></div>
         <h2>
-          {% if reason %}
-            {{ reason }}
+          {% if error_code is defined %}
+            {% if error_code is equalto githubrequiremfa %}
+              You must setup a security device ("MFA", "2FA") for your GitHub
+account in order to access this service. Please follow the
+<a href="https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/">GitHub documentation</a>
+to setup your device, then try logging in again.
+            {% elif error_code is equalto notingroup %}
+              Sorry, you do not have permission to access {{ client_name }}.
+Please contact mailtothisthing eus@mozilla.com if you should have access.
+            {% elif error_code is equalto primarynotverified %}
+              You primary email address is not yet verified. Please verify your
+email address with {{ connection_name }} in order to use this service.
+            {% elif error_code is equalto incorrectaccount %}
+              Sorry, you may not login using {{ connection_name }}. Please instead
+always login with {{ preferred_connection_name }}.
+            {% endif %}
+            {% if redirect_uri is defined %}
+              <a href="{{ redirect_uri }}">Go back</a>
+            {% endif %}
           {% else %}
             Oye, something went wrong.
           {% endif %}

--- a/dashboard/templates/forbidden.html
+++ b/dashboard/templates/forbidden.html
@@ -10,7 +10,7 @@
       <div class="panel">
         <div class="pointer"></div>
         <h2>
-            {% if token_verifier and token_verifier.verified == True %}
+            {% if token_verifier %}
                 {{ token_verifier.error_message()|safe }}
                 {% if token_verifier.redirect_uri %}
                   <a href="{{ token_verifier.redirect_uri }}">Go back</a>

--- a/dashboard/templates/forbidden.html
+++ b/dashboard/templates/forbidden.html
@@ -10,28 +10,14 @@
       <div class="panel">
         <div class="pointer"></div>
         <h2>
-          {% if error_code is defined %}
-            {% if error_code is equalto githubrequiremfa %}
-              You must setup a security device ("MFA", "2FA") for your GitHub
-account in order to access this service. Please follow the
-<a href="https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/">GitHub documentation</a>
-to setup your device, then try logging in again.
-            {% elif error_code is equalto notingroup %}
-              Sorry, you do not have permission to access {{ client_name }}.
-Please contact mailtothisthing eus@mozilla.com if you should have access.
-            {% elif error_code is equalto primarynotverified %}
-              You primary email address is not yet verified. Please verify your
-email address with {{ connection_name }} in order to use this service.
-            {% elif error_code is equalto incorrectaccount %}
-              Sorry, you may not login using {{ connection_name }}. Please instead
-always login with {{ preferred_connection_name }}.
+            {% if token_verifier and token_verifier.verified == True %}
+                {{ token_verifier.error_message()|safe }}
+                {% if token_verifier.redirect_uri %}
+                  <a href="{{ token_verifier.redirect_uri }}">Go back</a>
+                {% endif %}
+            {% else %}
+                 Oye, something went wrong.
             {% endif %}
-            {% if redirect_uri is defined %}
-              <a href="{{ redirect_uri }}">Go back</a>
-            {% endif %}
-          {% else %}
-            Oye, something went wrong.
-          {% endif %}
         </h2>
       </div>
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ rq
 jsmin
 cssmin
 pytest-flask
-pyjwt
+josepy
 cryptography==2.0
 pycrypto
 ecdsa


### PR DESCRIPTION
This continues on the work gene did yesterday but moves the code from the route into the dashboards object model.  Public cert is now base64 encoded in credstash instead to resolve LF inconsistency.  

Additionally error message logic has been moved into a method to simplify the logic in the error message views and make the code overall more testable.