### PR TITLE
Add date to alert banner message

### DIFF
--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -87,7 +87,7 @@
           <div class="alert-risk">{{ alert.risk }} risk</div>
         </div>
         <div class="mui-col-md-6 alert-message">
-          <p>{{ alert.summary }}</p>
+          <p>{{ alert.date }}: {{ alert.summary }}</p>
         </div>
         <div class="mui-col-md-3 alert-actions">
           <a href="/notifications" class="btn-alert"><img src="/static/img/alerts/info-white.svg" alt="alert-info"> <span class="info-text">More Info</span></a>


### PR DESCRIPTION
This adds the date of when the alert was created to the alert banner message. The date is already present in the alert notification center, so no need to change that.