### PR TITLE
change forbidden "Need Help?" link to discourse

### DIFF
--- a/dashboard/templates/forbidden.html
+++ b/dashboard/templates/forbidden.html
@@ -26,7 +26,7 @@
 
   <div class="mui-row section">
     <div class="mui-col-md-6 mui-col-md-offset-3">
-      <a href="https://mozilla.service-now.com/sp?id=sc_cat_item&sys_id=ca46b2794fcc2200f004ef6d0210c77c" class="mui-btn help">Need Help?</a>
+      <a href="https://discourse.mozilla.org/c/iam" class="mui-btn help">Need Help?</a>
 
       <a href="/dashboard" class="mui-btn return">Return to dashboard</a>
     </div>


### PR DESCRIPTION
Since users (including volunteers) who end up doing something wrong in the authentication process get redirected to `/forbidden`, putting the "Need Help?" link behind an LDAP authentication screen makes it rather useless.

While Discourse does also require users to authenticate to post through the web interface, it's also possible to create a post through email with no account set up. For a user hitting https://discourse.mozilla.org/c/iam, they'd need to press the envelope icon... which they might not realise they can use without being authenticated.

We could, instead, make the "Need Help?" link a `mailto:` link for the Discourse category, but then users may not understand that their post is going to be public.

Instead of that, it's possible for us to set up a private group inbox in Discourse that anybody can email, but only certain people can see (i.e. us - we can use an IAM group to control access).

Not sure which of these is the best solution, I'll defer to others for judgement. But I think they're *all* better than an unusable button. 😉 