### PR TITLE
Use real buttons with text as close buttons

### DIFF
--- a/dashboard/static/css/base.scss
+++ b/dashboard/static/css/base.scss
@@ -58,6 +58,11 @@ body {
     font-family: 'Open Sans', sans-serif;
 }
 
+.visually-hidden {
+    position: absolute;
+    left: -9999em;
+}
+
 .yellow-border {
     border-color: $yellow;
 }
@@ -371,6 +376,9 @@ body {
                 margin-left: 5px;
                 padding: 5px;
                 vertical-align: text-top;
+                background-color: transparent;
+                border: 0;
+                font-weight: 100;
 
                 @media all and (max-width: 543px) {
                     position: absolute;

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -77,7 +77,7 @@
       </div>
       <div class="mui-col-md-3 alert-actions">
         <a href="https://beta.mozilla.org/" class="btn-alert" target="_blank"><img src="/static/img/alerts/arrow-right-white.svg" alt="alert-info"> Download</a>
-        <span id="close-alert" class="closebtn">&times;</span>
+        <button type="button" id="close-alert" class="closebtn"><span aria-hidden="true">&times;</span><span class="visually-hidden">Dismiss</button>
       </div>
     </div>
 
@@ -95,7 +95,7 @@
           <a href="#" id="escalate-alert" class="btn-alert"><img src="/static/img/alerts/info-white.svg" alt="alert-info"> <span class="info-text">Mark False Positive</span></a>
           <a href="{{ alert.url }}" class="btn-alert" target="_blank"><img src="/static/img/alerts/arrow-right-white.svg" alt="alert-info"> {{ alert.url_title }}</a>
 
-          <span id="submit-alert" class="closebtn" data-alert-id="{{ alert.get('alert_id') }}">&times;</span>
+          <button type="button" id="submit-alert" class="closebtn" data-alert-id="{{ alert.get('alert_id') }}"><span aria-hidden="true">&times;</span><span class="visually-hidden">Dismiss</button>
         </div>
       </div>
     {% endfor %}


### PR DESCRIPTION
I've made this change, so that they are easier to use by screenreader and keyboard users.

This is what I've done:

* we've added ‘accessible text’ of “Dismiss” to the buttons. People with a screenreader can't see the X, but they will hear 'Dismiss'. I've made the actual X invisible to screenreaders (so that they don't hear 'X') using the `aria-hidden` attribute
* now that we use a `button` element in HTML, the button can be focused and interacted with using a keyboard (and it gets announced as 'button' by screenreaders; win win win)

Signed-off-by: Hidde de Vries <hidde@hiddedevries.nl>