### PR TITLE
Support Firefox Accounts as connection name for error messages

### DIFF
--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -93,6 +93,7 @@ class tokenVerification(object):
         CONNECTION_NAMES = {
             'google-oauth2': 'Google',
             'github': 'GitHub',
+            'firefoxaccounts': 'Firefox Accounts',
             'Mozilla-LDAP-Dev': 'LDAP',
             'Mozilla-LDAP': 'LDAP',
             'email': 'passwordless email'


### PR DESCRIPTION
See also https://github.com/mozilla-iam/auth0-deploy/issues/188