### PR TITLE
Add link to NLX Auto-login Settings

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -135,6 +135,16 @@ def logout():
     )
     return redirect(logout_url, code=302)
 
+@app.route('/autologin-settings')
+def showautologinsettings():
+    """
+    Redirect to NLX Auto-login Settings page
+    """
+    autologin_settings_url = "https://{}/login?client={}&action=autologin_settings".format(
+        oidc_config.OIDC_DOMAIN, oidc_config.OIDC_CLIENT_ID
+    )
+    return redirect(autologin_settings_url, code=302)
+
 
 @app.route('/signout.html')
 def signout():

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -135,6 +135,7 @@ def logout():
     )
     return redirect(logout_url, code=302)
 
+
 @app.route('/autologin-settings')
 def showautologinsettings():
     """

--- a/dashboard/static/css/base.scss
+++ b/dashboard/static/css/base.scss
@@ -220,7 +220,7 @@ body {
         &.enabled {
             background-color: black;
             color: white;
-            width: 217px;
+            width: 250px;
             border-bottom: 1px solid #5b555c;
             border-left: none;
             height: calc(#{$appbar-height} - 1px);
@@ -869,7 +869,7 @@ footer {
     top: $appbar-height;
     right: 0;
     display: none;
-    width: 217px;
+    width: 250px;
 
     &:focus {
         outline: none;
@@ -1157,7 +1157,7 @@ footer {
 
             &.enabled {
                 height: calc(#{$appbar-height} - 1px);
-                width: 200px;
+                width: 250px;
 
                 .name {
                     height: calc(#{$appbar-height} - 1px);
@@ -1202,7 +1202,7 @@ footer {
     .user-menu {
         top: $appbar-height;
         height: 100%;
-        width: 200px;
+        width: 250px;
 
         a {
             padding: 0 30px 0 15px;

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -63,6 +63,7 @@
     <a href="https://mozillians.org/oidc/authenticate/?next=/user/edit/" target="_blank"><span>Settings</span> <img class="menu-icon" src="/static/img/settings.svg" alt=""></a>
     <a {% if user.alerts %}href="/notifications"{% else %}href="#" class="inactive"{% endif %}><span>Notifications</span> <img class="menu-icon" src="/static/img/alerts/notification-white.svg" alt=""></a>
     <a href="/logout"><span>Logout</span> <img class="menu-icon"src="/static/img/logout.svg" alt=""></a>
+    <a href="/autologin-settings"><span>Enable / Disable Auto-login</span></a>
     <div class="coming-soon"><span>coming soon</span></div>
     <a href="#" class="inactive"><span>Access Request</span> <img class="menu-icon"src="/static/img/request.svg" alt=""></a>
   </div>


### PR DESCRIPTION
This links to the autologin settings page, currently live in NLX DEV.

A great addition would be to also pass the user's **email address** (as `user_email`) and **login method** (as `user_login_method`) as NLX DEV supports displaying those, but for that we'd need them to be in the user model.