### PR TITLE
Make escalate icon consistent with dashboard

### DIFF
--- a/dashboard/templates/notifications.html
+++ b/dashboard/templates/notifications.html
@@ -46,7 +46,7 @@
             </a>
             {% if alert.get('state') != 'escalate' and alert.get('alert_code') == '416c65727447656f6d6f64656c' %}
             <button type="button" data-process-action="escalate" class="btn-alert" data-process-action-success="This alert has been escalated to the Mozilla Operations Center." data-process-action-error="An error has occurred, please try again later.">
-              {% include 'icons/info.svg' %}
+              {% include 'icons/arrow-right.svg' %}
               <span class="info-text">Escalate to Security</span>
             </button>
             {% endif %}


### PR DESCRIPTION
I noticed that the icon used for ‘Escalate’ on the Notification Centre page wasn't the same as the one on the frontpage. This fixes that