### PR TITLE
add alert api endpoint

### DIFF
--- a/dashboard/api/exceptions.py
+++ b/dashboard/api/exceptions.py
@@ -1,0 +1,5 @@
+# Error handler
+class AuthError(Exception):
+    def __init__(self, error, status_code):
+        self.error = error
+        self.status_code = status_code

--- a/dashboard/api/idp.py
+++ b/dashboard/api/idp.py
@@ -1,0 +1,123 @@
+import json
+import logging
+from functools import wraps
+from flask import request
+from flask import _request_ctx_stack
+from six.moves.urllib.request import urlopen
+from jose import jwt
+from api.exceptions import AuthError
+
+logger = logging.getLogger(__name__)
+
+
+class AuthorizeAPI(object):
+    def __init__(self, app, oidc_config):
+        self.app = app
+        self.algorithms = 'RS256'
+        self.auth0_domain = oidc_config.OIDC_DOMAIN  # auth.mozilla.auth0.com
+        self.audience = self._get_audience(self.app.config)
+
+    def _get_audience(self, app_config):
+        if app_config['SERVER_NAME'] == 'localhost:5000':
+            return 'https://sso.allizom.org'
+        else:
+            return 'https://' + self.app.config.get('SERVER_NAME', 'sso.mozilla.com')  # sso.mozilla.com
+
+    # Format error response and append status code
+    def get_token_auth_header(self):
+        """Obtains the Access Token from the Authorization Header
+        """
+        auth = request.headers.get("Authorization", None)
+        if not auth:
+            raise AuthError({"code": "authorization_header_missing",
+                            "description":
+                                "Authorization header is expected"}, 401)
+
+        parts = auth.split()
+
+        if parts[0].lower() != "bearer":
+            raise AuthError({"code": "invalid_header",
+                            "description":
+                                "Authorization header must start with"
+                                " Bearer"}, 401)
+        elif len(parts) == 1:
+            raise AuthError({"code": "invalid_header",
+                            "description": "Token not found"}, 401)
+        elif len(parts) > 2:
+            raise AuthError({"code": "invalid_header",
+                            "description":
+                                "Authorization header must be"
+                                " Bearer token"}, 401)
+
+        token = parts[1]
+        return token
+
+    def get_jwks(self):
+        jsonurl = urlopen("https://" + self.auth0_domain + "/.well-known/jwks.json")
+        jwks = json.loads(jsonurl.read())
+        return jwks
+
+    def requires_api_auth(self, f):
+        """Determines if the Access Token is valid
+        """
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            token = self.get_token_auth_header()
+            jwks = self.get_jwks()
+            unverified_header = jwt.get_unverified_header(token)
+            rsa_key = {}
+            for key in jwks["keys"]:
+                if key["kid"] == unverified_header["kid"]:
+                    rsa_key = {
+                        "kty": key["kty"],
+                        "kid": key["kid"],
+                        "use": key["use"],
+                        "n": key["n"],
+                        "e": key["e"]
+                    }
+            if rsa_key:
+                try:
+                    logger.debug(token)
+                    payload = jwt.decode(
+                        token,
+                        rsa_key,
+                        algorithms=self.algorithms,
+                        audience=self.audience,
+                        issuer="https://" + self.auth0_domain + "/"
+                    )
+                except jwt.ExpiredSignatureError as e:
+                    logger.error(e)
+                    raise AuthError({"code": "token_expired",
+                                    "description": "token is expired"}, 401)
+                except jwt.JWTClaimsError as e:
+                    logger.error(e)
+                    raise AuthError({"code": "invalid_claims",
+                                    "description":
+                                        "incorrect claims,"
+                                        "please check the audience and issuer"}, 401)
+                except Exception as e:
+                    logger.error(e)
+                    raise AuthError({"code": "invalid_header",
+                                    "description":
+                                        "Unable to parse authentication"
+                                        " token."}, 401)
+
+                _request_ctx_stack.top.current_user = payload
+                return f(*args, **kwargs)
+            raise AuthError({"code": "invalid_header",
+                            "description": "Unable to find appropriate key"}, 401)
+        return decorated
+
+    def requires_scope(self, required_scope):
+        """Determines if the required scope is present in the Access Token
+        Args:
+            required_scope (str): The scope required to access the resource
+        """
+        token = self.get_token_auth_header()
+        unverified_claims = jwt.get_unverified_claims(token)
+        if unverified_claims.get("scope"):
+                token_scopes = unverified_claims["scope"].split()
+                for token_scope in token_scopes:
+                    if token_scope == required_scope:
+                        return True
+        return False

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -21,10 +21,13 @@ import config
 import person
 import vanity
 
+from api import idp
+from api import exceptions
 from csp import DASHBOARD_CSP
 from models.user import User
 from models.user import FakeUser
 from op.yaml_loader import Application
+from models.alert import Alert
 from models.alert import FakeAlert
 from models.alert import Rules
 from models.tile import S3Transfer
@@ -68,6 +71,8 @@ oidc = authentication.auth(app)
 person_api = person.API()
 
 vanity_router = vanity.Router(app, app_list).setup()
+
+api = idp.AuthorizeAPI(app, oidc_config)
 
 
 @app.route('/favicon.ico')
@@ -242,6 +247,22 @@ def alert_faking():
             fake_alerts.create_fake_alerts()
 
     return redirect('/dashboard', code=302)
+
+
+@app.route('/api/v1/alert', methods=['GET'])
+@api.requires_api_auth
+def alert_api():
+    if request.method == 'GET' and api.requires_scope("read:alert"):
+        user_id = request.args.get('user_id')
+        alerts = Alert().find(user_id)
+        result = Alert().to_summary(alerts)
+        return jsonify(result)
+    raise exceptions.AuthError(
+        {
+            "code": "Unauthorized",
+            "description": "Scope not matched.  Access Denied."
+        }, 403
+    )
 
 
 @app.route('/info')

--- a/dashboard/models/alert.py
+++ b/dashboard/models/alert.py
@@ -218,6 +218,31 @@ class Alert(object):
             'inactive_alerts': inactive_alerts
         }
 
+    def to_summary(self, alert_dict):
+        """
+        Takes list of lists of alerts as formatted in self.find()
+        Return statuses for consumption in NLX
+        """
+        high_count = 0
+        maximum_count = 0
+        medium_count = 0
+        low_count = 0
+
+        for alert in alert_dict.get('visible_alerts', []):
+            if alert.get('risk') == 'high':
+                high_count = high_count + 1
+            if alert.get('risk') == 'maximum':
+                maximum_count = maximum_count + 1
+            if alert.get('risk') == 'medium':
+                medium_count = medium_count + 1
+            if alert.get('risk') == 'low':
+                low_count = low_count + 1
+
+        return {
+            'alerts':
+                {'maximum': maximum_count, 'high': high_count, 'medium': medium_count, 'low': low_count}
+        }
+
     def find_by_id(self, alert_id):
         """
         Search dynamodb for all non-expired alerts for a given user.

--- a/dashboard/models/alert.py
+++ b/dashboard/models/alert.py
@@ -7,7 +7,6 @@ import logging
 import os
 import requests
 
-from boto3.dynamodb.conditions import Attr
 from boto3.dynamodb.conditions import Key
 from faker import Faker
 
@@ -256,7 +255,7 @@ class Alert(object):
         self.connect_dynamodb()
 
         response = self.dynamodb.query(
-             KeyConditionExpression=Key('alert_id').eq(alert_id)
+            KeyConditionExpression=Key('alert_id').eq(alert_id)
         )
 
         if response.get('Items'):

--- a/dashboard/models/alert.py
+++ b/dashboard/models/alert.py
@@ -7,8 +7,8 @@ import logging
 import os
 import requests
 
-
 from boto3.dynamodb.conditions import Attr
+from boto3.dynamodb.conditions import Key
 from faker import Faker
 
 
@@ -177,16 +177,20 @@ class Alert(object):
         try:
             self.connect_dynamodb()
 
-            response = self.dynamodb.scan(
-                FilterExpression=Attr('user_id').eq(user_id)
+            response = self.dynamodb.query(
+                IndexName='user_id-index',
+                Select='ALL_ATTRIBUTES',
+                KeyConditionExpression=Key('user_id').eq(user_id)
             )
 
             alerts = response.get('Items', [])
 
             if response:
                 while 'LastEvaluatedKey' in response:
-                    response = self.dynamodb.scan(
-                        FilterExpression=Attr('user_id').eq(user_id),
+                    response = self.dynamodb.query(
+                        IndexName='user_id-index',
+                        Select='ALL_ATTRIBUTES',
+                        KeyConditionExpression=Key('user_id').eq(user_id),
                         ExclusiveStartKey=response['LastEvaluatedKey']
                     )
                     alerts.extend(response['Items'])
@@ -251,11 +255,14 @@ class Alert(object):
         """
         self.connect_dynamodb()
 
-        response = self.dynamodb.scan(
-            FilterExpression=Attr('alert_id').eq(alert_id)
+        response = self.dynamodb.query(
+             KeyConditionExpression=Key('alert_id').eq(alert_id)
         )
 
-        return response.get('Items')[0]
+        if response.get('Items'):
+            return response.get('Items')[0]
+
+        return {}
 
     def _create_alert_id(self):
         """
@@ -296,6 +303,14 @@ class Rules(object):
                 'duplicate': False
             }
             self.alert.find_or_create_by(alert_dict=alert_dict, user_id=self.userinfo.get('user_id'))
+        if not self._firefox_out_of_date():
+            # Clear any active alerts for firefox out of date.
+            alerts = self.alert.find(self.userinfo.get('user_id'))
+            for alert in alerts.get('visible_alerts'):
+                if alert.get('alert_code') == '63f675d8896f4fb2b3caa204c8c2761e':
+                    self.alert.destroy(
+                        alert_id=alert.get('alert_id'), user_id=alert.get('user_id')
+                    )
 
     def _firefox_info(self):
         release_json = requests.get('https://product-details.mozilla.org/1.0/firefox_versions.json')
@@ -355,7 +370,7 @@ class FakeAlert(object):
 
     def _create_fake_browser_alert(self):
         alert_dict = {
-            'alert_code': '63f675d8896f4fb2b3caa204c8c2761e',
+            'alert_code': 'a63f675d8896f4fb2b3caa204c8c2761e',
             'user_id': self.user_id,
             'risk': 'medium',
             'summary': 'Your version of Firefox is older than the current stable release.',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ credstash==1.14.0
 cryptography==2.0
 cssmin==0.2.0
 docutils==0.14
+ecdsa==0.13
 execnet==1.5.0
 Faker==0.8.7
 Flask==0.12.2
@@ -39,6 +40,7 @@ oic==0.11.0.1
 pathtools==0.1.2
 pluggy==0.6.0
 py==1.5.2
+pyasn1==0.4.3
 pycparser==2.18
 pycryptodomex==3.4.7
 pyjwkest==1.4.0
@@ -48,8 +50,10 @@ pytest-flask==0.10.0
 pytest-forked==0.2
 pytest-xdist==1.20.1
 python-dateutil==2.6.1
+python-jose==3.0.0
 PyYAML==3.12
 requests==2.18.4
+rsa==3.4.2
 s3transfer==0.1.12
 six==1.11.0
 text-unidecode==1.1


### PR DESCRIPTION
Adds an alert API endpoint that uses standard auth0 bearer token based auth to retrieve counts of unacknowledged alerts by severity for a user.

```
curl --request GET \
  --url http://localhost:5000/api/v1/alert?user_id=ad%7CMozilla-LDAP%7Cakrug \
  --header 'authorization: Bearer $BEARER'
```

Returns dict of number of unack'ed alerts.

```
{
  "alerts": {
    "high": 1,
    "low": 0,
    "maximum": 0,
    "medium": 1
  }
}
```