### PR TITLE
Add a message indicating that you may have to log out of Firefox Account and back in again. 

### DIFF
--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -139,7 +139,9 @@ class tokenVerification(object):
             error_text = \
                 "You must setup a security device(\"MFA"", \"2FA\") for your Firefox Account in order to access \
                 this service. Please setup a <a href=\"https://accounts.firefox.com\">security device</a>, then \
-                try logging in again."
+                try logging in again.\n\
+                If you have just setup your security device and you see this message, please log out of Firefox \
+                Account and back in again."
         elif error_code == 'notingroup':
             error_text = "Sorry, you do not have permission to access {client}.  \
             Please contact eus@mozilla.com if you should have access.".format(client=self.data.get('client'))


### PR DESCRIPTION
Add a message indicating that you may have to log out of Firefox Account and back in again. This is due to possible caching delays in Firefox Account, which will be most likely resolved in the future. In the mean time, this should help the few users that could run into this. It's thanksfully fairly rare.