### PR TITLE
Replace extraneous call to _firefox_out_of_date() with else.

### DIFF
--- a/dashboard/models/alert.py
+++ b/dashboard/models/alert.py
@@ -302,7 +302,7 @@ class Rules(object):
                 'duplicate': False
             }
             self.alert.find_or_create_by(alert_dict=alert_dict, user_id=self.userinfo.get('user_id'))
-        if not self._firefox_out_of_date():
+        else:
             # Clear any active alerts for firefox out of date.
             alerts = self.alert.find(self.userinfo.get('user_id'))
             for alert in alerts.get('visible_alerts'):


### PR DESCRIPTION
In `dashboard/models/alert.py`, there's an if/else condition on line 289 and 305; however, instead of using `if _func` / `else:`, it uses `if _func` / `if not _func`, which results in _func being called twice unnecessarily. This patch replaces the later `if not` with `else`.