### PR TITLE
Purge old alerts

### DIFF
--- a/dashboard/models/alert.py
+++ b/dashboard/models/alert.py
@@ -203,7 +203,9 @@ class Alert(object):
         escalations = []
 
         for alert in alerts:
-            if alert.get('state', '') == 'acknowledge':
+            if self._alert_is_expired(alert):
+                self.destroy(alert.get('alert_id'), user_id)
+            elif alert.get('state', '') == 'acknowledge':
                 inactive_alerts.append(alert)
             elif alert.get('helpfulness', '') != '':
                 ranked_alerts.append(alert)
@@ -220,6 +222,16 @@ class Alert(object):
             'escalations': escalations,
             'inactive_alerts': inactive_alerts
         }
+
+    def _alert_is_expired(self, alert):
+        now = datetime.datetime.today()
+        threshold = now - datetime.timedelta(days=7)
+        alert_time = datetime.datetime.strptime(alert.get('date'), '%Y-%m-%d')
+
+        if alert_time < threshold:
+            return True
+        else:
+            return False
 
     def to_summary(self, alert_dict):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ argh==0.26.2
 asn1crypto==0.23.0
 attrs==17.3.0
 Beaker==1.9.0
-boto3==1.6.16
-botocore==1.9.16
+boto3==1.7.79
+botocore==1.10.79
 certifi==2017.11.5
 cffi==1.11.2
 chardet==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,6 @@ Flask-Assets==0.12
 Flask-pyoidc==1.2.0
 flask-talisman==0.4.0
 future==0.16.0
-gevent==1.2.2
-greenlet==0.4.12
 gunicorn==19.7.1
 idna==2.6
 itsdangerous==0.24
@@ -51,7 +49,6 @@ pytest-forked==0.2
 pytest-xdist==1.20.1
 python-dateutil==2.6.1
 python-jose==3.0.0
-PyYAML==3.12
 requests==2.18.4
 rsa==3.4.2
 s3transfer==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ argh==0.26.2
 asn1crypto==0.23.0
 attrs==17.3.0
 Beaker==1.9.0
-boto3==1.4.8
-botocore==1.8.8
+boto3==1.6.16
+botocore==1.9.16
 certifi==2017.11.5
 cffi==1.11.2
 chardet==3.0.4

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -71,6 +71,89 @@ class TestAlerts(object):
         res = a.destroy(alert_id=sample_alert_id, user_id='bob|ad|123456')
         assert res['ResponseMetadata']['HTTPStatusCode'] == 200
 
+    @mock_dynamodb2
+    def test_alert_purge(self):
+        session = Session()
+        # Get the service resource
+        dynamodb = session.resource('dynamodb')
+        dynamodb.create_table(
+            TableName='sso-dashboard-alert1',
+            KeySchema=[
+                {
+                    'AttributeName': 'alert_id',
+                    'KeyType': 'HASH'
+                }
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'alert_id',
+                    'AttributeType': 'S'
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 5,
+                'WriteCapacityUnits': 5
+            }
+        )
+
+        client = session.client('dynamodb')
+        response = client.update_table(
+            TableName = 'sso-dashboard-alert1',
+            GlobalSecondaryIndexUpdates=[
+                {
+                    'Create': {
+                        'IndexName': 'user_id-index',
+                        'KeySchema': [
+                            {
+                                'AttributeName': 'user_id',
+                                'KeyType': 'HASH'
+                            }
+                        ],
+                        'Projection': {
+                            'ProjectionType': 'ALL'
+                        },
+                        'ProvisionedThroughput': {
+                            'ReadCapacityUnits': 5,
+                            'WriteCapacityUnits': 5
+                        }
+                    }
+                }
+            ],
+        )
+
+        self.table = dynamodb.Table('sso-dashboard-alert1')
+        self.table.meta.client.get_waiter('table_exists').wait(TableName='sso-dashboard-alert1')
+
+        a = alert.Alert()
+        a.dynamodb = self.table
+
+        alert_dict = {
+              "alert_code": "416c65727447656f6d6f64656c",
+              "alert_id": "1c7c506eb221f6206becb8ef0d96f6",
+              "alert_str_json": "{\"category\": \"geomodel\", \"severity\": \"NOTICE\", \"utctimestamp\": \"2018-08-05T10:31:08.469722+00:00\", \"tags\": [\"geomodel\"], \"url\": \"https://mana.mozilla.org/wiki/display/SECURITY/Notes%3A+MozDef+geomodel+alerts\", \"ircchannel\": null, \"summary\": \"shong@mozilla.com NEWCOUNTRY Lewisham, United Kingdom access from x.x.x.x (auth0) [deviation:5.966573556070519] last activity was from Berlin, Germany (928 km away) approx 46.13 hours before\", \"notify_mozdefbot\": false, \"details\": {\"category\": \"NEWCOUNTRY\", \"locality_details\": {\"city\": \"Lewisham\", \"country\": \"United Kingdom\"}, \"previous_locality_details\": {\"city\": \"Berlin\", \"country\": \"Germany\"}, \"source_ip\": \"x.x.x.x\", \"principal\": \"shong@mozilla.com\"}, \"events\": [{\"documentindex\": \"events-20180805\", \"documentsource\": {\"category\": \"geomodelnotice\", \"processid\": \"28953\", \"receivedtimestamp\": \"2018-08-05T10:30:29.181506+00:00\", \"hostname\": \"eis-automation1.private.mdc1.mozilla.com\", \"severity\": \"NOTICE\", \"utctimestamp\": \"2018-08-05T10:30:31.921093+00:00\", \"tags\": [\"geomodel\"], \"timestamp\": \"2018-08-05T10:30:31.921093+00:00\", \"alerts\": [{\"index\": \"alerts-201808\", \"type\": \"alert\", \"id\": \"AWUJpEYAvM5cwH73CHwQ\"}], \"mozdefhostname\": \"mozdef2.private.mdc1.mozilla.com\", \"summary\": \"shong@mozilla.com NEWCOUNTRY Lewisham, United Kingdom access from x.x.x.x (auth0) [deviation:5.966573556070519] last activity was from Berlin, Germany (928 km away) approx 46.13 hours before\", \"alert_names\": [\"AlertGeomodel\"], \"processname\": \"/home/geomodel/go/bin/geomodel\", \"details\": {\"category\": \"NEWCOUNTRY\", \"prev_distance\": 928.4467662801642, \"prev_locality_details\": {\"city\": \"Berlin\", \"country\": \"Germany\"}, \"prev_timestamp\": \"2018-08-03T12:12:22.185Z\", \"severity\": 2, \"event_time\": \"2018-08-05T10:20:04.452Z\", \"principal\": \"akrug@mozilla.com\", \"longitude\": -0.0167, \"source_ipv4\": \"x.x.x.x\", \"latitude\": 51.45, \"locality_details\": {\"city\": \"Lewisham\", \"country\": \"United Kingdom\"}, \"informer\": \"auth0\", \"prev_latitude\": 52.5009, \"weight_deviation\": 5.966573556070519, \"prev_longitude\": 13.4356}, \"source\": \"UNKNOWN\"}, \"documentid\": \"AWUJohdQfpt4w200mjPd\", \"documenttype\": \"event\"}]}",
+              "date": "2018-08-05",
+              "description": "This alert is created based on geo ip information about the last login of a user.",
+              "duplicate": True,
+              "risk": "high",
+              "summary": "Did you recently login from Lewisham, United Kingdom (x.x.x.x)?",
+              "url": "https://mana.mozilla.org/wiki/display/SECURITY/Alert%3A+Change+in+Country",
+              "url_title": "Get Help",
+              "user_id": "ad|Mozilla-LDAP|akrug"
+        }
+
+        res = a.create(alert_dict=alert_dict)
+        sample_alert_id = res['Attributes']['alert_id']
+
+        assert res['ResponseMetadata']['HTTPStatusCode'] == 200
+
+        res = a.find('ad|Mozilla-LDAP|akrug')
+
+        for this_alert in res.get('visible_alerts'):
+            if alert_dict.get('alert_id') == this_alert.get('alert_id'):
+                assert 0
+            else:
+                pass
+
 
 class TestRules(object):
     def test_object_init(self):

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -98,7 +98,7 @@ class TestAlerts(object):
 
         client = session.client('dynamodb')
         response = client.update_table(
-            TableName = 'sso-dashboard-alert1',
+            TableName='sso-dashboard-alert1',
             GlobalSecondaryIndexUpdates=[
                 {
                     'Create': {
@@ -121,6 +121,8 @@ class TestAlerts(object):
             ],
         )
 
+        assert response is not None
+
         self.table = dynamodb.Table('sso-dashboard-alert1')
         self.table.meta.client.get_waiter('table_exists').wait(TableName='sso-dashboard-alert1')
 
@@ -128,22 +130,21 @@ class TestAlerts(object):
         a.dynamodb = self.table
 
         alert_dict = {
-              "alert_code": "416c65727447656f6d6f64656c",
-              "alert_id": "1c7c506eb221f6206becb8ef0d96f6",
-              "alert_str_json": "{\"category\": \"geomodel\", \"severity\": \"NOTICE\", \"utctimestamp\": \"2018-08-05T10:31:08.469722+00:00\", \"tags\": [\"geomodel\"], \"url\": \"https://mana.mozilla.org/wiki/display/SECURITY/Notes%3A+MozDef+geomodel+alerts\", \"ircchannel\": null, \"summary\": \"shong@mozilla.com NEWCOUNTRY Lewisham, United Kingdom access from x.x.x.x (auth0) [deviation:5.966573556070519] last activity was from Berlin, Germany (928 km away) approx 46.13 hours before\", \"notify_mozdefbot\": false, \"details\": {\"category\": \"NEWCOUNTRY\", \"locality_details\": {\"city\": \"Lewisham\", \"country\": \"United Kingdom\"}, \"previous_locality_details\": {\"city\": \"Berlin\", \"country\": \"Germany\"}, \"source_ip\": \"x.x.x.x\", \"principal\": \"shong@mozilla.com\"}, \"events\": [{\"documentindex\": \"events-20180805\", \"documentsource\": {\"category\": \"geomodelnotice\", \"processid\": \"28953\", \"receivedtimestamp\": \"2018-08-05T10:30:29.181506+00:00\", \"hostname\": \"eis-automation1.private.mdc1.mozilla.com\", \"severity\": \"NOTICE\", \"utctimestamp\": \"2018-08-05T10:30:31.921093+00:00\", \"tags\": [\"geomodel\"], \"timestamp\": \"2018-08-05T10:30:31.921093+00:00\", \"alerts\": [{\"index\": \"alerts-201808\", \"type\": \"alert\", \"id\": \"AWUJpEYAvM5cwH73CHwQ\"}], \"mozdefhostname\": \"mozdef2.private.mdc1.mozilla.com\", \"summary\": \"shong@mozilla.com NEWCOUNTRY Lewisham, United Kingdom access from x.x.x.x (auth0) [deviation:5.966573556070519] last activity was from Berlin, Germany (928 km away) approx 46.13 hours before\", \"alert_names\": [\"AlertGeomodel\"], \"processname\": \"/home/geomodel/go/bin/geomodel\", \"details\": {\"category\": \"NEWCOUNTRY\", \"prev_distance\": 928.4467662801642, \"prev_locality_details\": {\"city\": \"Berlin\", \"country\": \"Germany\"}, \"prev_timestamp\": \"2018-08-03T12:12:22.185Z\", \"severity\": 2, \"event_time\": \"2018-08-05T10:20:04.452Z\", \"principal\": \"akrug@mozilla.com\", \"longitude\": -0.0167, \"source_ipv4\": \"x.x.x.x\", \"latitude\": 51.45, \"locality_details\": {\"city\": \"Lewisham\", \"country\": \"United Kingdom\"}, \"informer\": \"auth0\", \"prev_latitude\": 52.5009, \"weight_deviation\": 5.966573556070519, \"prev_longitude\": 13.4356}, \"source\": \"UNKNOWN\"}, \"documentid\": \"AWUJohdQfpt4w200mjPd\", \"documenttype\": \"event\"}]}",
-              "date": "2018-08-05",
-              "description": "This alert is created based on geo ip information about the last login of a user.",
-              "duplicate": True,
-              "risk": "high",
-              "summary": "Did you recently login from Lewisham, United Kingdom (x.x.x.x)?",
-              "url": "https://mana.mozilla.org/wiki/display/SECURITY/Alert%3A+Change+in+Country",
-              "url_title": "Get Help",
-              "user_id": "ad|Mozilla-LDAP|akrug"
+            "alert_code": "416c65727447656f6d6f64656c",
+            "alert_id": "1c7c506eb221f6206becb8ef0d96f6",
+            "alert_str_json": "foo",
+            "date": "2018-08-05",
+            "description": "This alert is created based on geo ip information about the last login of a user.",
+            "duplicate": True,
+            "risk": "high",
+            "summary": "Did you recently login from Lewisham, United Kingdom (x.x.x.x)?",
+            "url": "https://mana.mozilla.org/wiki/display/SECURITY/Alert%3A+Change+in+Country",
+            "url_title": "Get Help",
+            "user_id": "ad|Mozilla-LDAP|akrug"
         }
 
         res = a.create(alert_dict=alert_dict)
-        sample_alert_id = res['Attributes']['alert_id']
-
+        assert res is not None
         assert res['ResponseMetadata']['HTTPStatusCode'] == 200
 
         res = a.find('ad|Mozilla-LDAP|akrug')


### PR DESCRIPTION
* Auto purge alerts older than 7 days when pulling back from the alerts table.
* Improve coverage of alerts class
* Add global secondary index to mocks
