### PR TITLE
Modify alert messages witdh

### DIFF
--- a/dashboard/static/css/base.scss
+++ b/dashboard/static/css/base.scss
@@ -354,7 +354,7 @@ body {
 
         > p {
             margin: 1em 0;
-            max-width: 35em;
+            max-width: 60em;
 
             @media (min-width: 40em) {
                 margin: 1em auto;


### PR DESCRIPTION
This expands the width of the alert messages, so the updated geomodel summary will not get chopped up into 2 lines.