### PR TITLE
Remove secure account terminology

### DIFF
--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -156,7 +156,7 @@ class tokenVerification(object):
             )
         elif error_code == 'incorrectaccount':
             error_text = "Sorry, you may not login using {connection_name}.  \
-             We require login to be performed using the most secure method available for your account, which is \
+             Instead, please use \
              {preferred_connection_name}.".format(
                 connection_name=self._get_connection_name(self.jws_data.get('connection', '')),
                 preferred_connection_name=self._get_connection_name(self.preferred_connection_name)


### PR DESCRIPTION
In a [Discourse comment](https://discourse.mozilla.org/t/2fa-cannot-be-mandatory/30352/21?u=hmitsch) we saw that the `secure account` terminology is prone to misinterpretation.

This PR suggests to make the wording less controversial while maintaining clear next steps for users to avoid getting trapped in a dead end.