### PR TITLE
bind Prometheus exporter to new port

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -49,6 +49,7 @@ app = Flask(__name__)
 try:
     if os.environ["ENABLE_DASHBOARD_MONITORING"]:
         metrics = PrometheusMetrics(app)
+        metrics.start_http_server(9000)
 except KeyError:
     logger.info("Prometheus exporter disabled, set ENABLE_DASHBOARD_MONITORING to enable it.")
 


### PR DESCRIPTION
By default, the Prometheus exporter will add a route for `/metrics` to
the running app. In our case, the use of SERVER_NAME results in 404s for
these requests. This is an attempt to workaround that. If I understand
correctly, this change provides us with a new app context which avoids
that problem.

In testing, I can access the `/metrics` endpoint with any host header
and the server responds with the metrics.



> Note in order to land a PR you must conform to the requirements outlined in https://github.com/mozilla-iam/mozilla-iam/blob/master/GitHub-Security-Settings.md

Branch Protection Rules on master, and production branches are set as follows:
    Protect this branch
    Require pull request reviews before merging
    Require signed commits
    Include administrators
    Restrict who can push to this branch
        Include the teams which should be able to affect code (i.e. write, commit, push code)
        Do NOT include the teams that may not (such as issue managers, bots, etc.)

NOTE: "Restrict who can push to this branch" is effectively the control by which you may allow specific teams to write issues without being able to change code. This does not prevent these teams from contributing through pull-requests. It prevents these teams from merging code.