### PR TITLE
enabling multiprocess for Prometheus export

### DIFF
--- a/ansible/roles/dashboard/files/nginx/nginx.conf
+++ b/ansible/roles/dashboard/files/nginx/nginx.conf
@@ -59,8 +59,10 @@ http {
 
         }
 
-
-
+        location /metrics {
+          deny all;
+          return 403;
+        }
 
     }
 
@@ -86,7 +88,10 @@ http {
 
         }
 
-
+        location /metrics {
+          deny all;
+          return 403;
+        }
 
     }
 }

--- a/ansible/roles/dashboard/files/sso-dashboard.ini
+++ b/ansible/roles/dashboard/files/sso-dashboard.ini
@@ -15,5 +15,5 @@ preferred_url_scheme=https
 #oidc_client_secret=redacted
 
 #Ops features
-enable_prometheus_monitoring=True
+enable_prometheus_monitoring=False
 prometheus_monitoring_port=9000

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,6 +15,8 @@ from flask import session
 from flask_assets import Bundle
 from flask_assets import Environment
 from flask_talisman import Talisman
+from prometheus_client import multiprocess
+from prometheus_client.core import CollectorRegistry
 from prometheus_flask_exporter import PrometheusMetrics
 
 from dashboard import auth
@@ -48,6 +50,9 @@ app = Flask(__name__)
 everett_config = get_config()
 # Enable monitoring endpoint
 if everett_config('enable_prometheus_monitoring', namespace='sso-dashboard', default='False') == 'True':
+    os.environ["prometheus_multiproc_dir"] = "/tmp"
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry, path='/tmp')
     metrics = PrometheusMetrics(app)
     metrics.start_http_server(
         int(

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ watchtower==0.5.2
 webassets==0.12.1
 Werkzeug==0.12.2
 prometheus-flask-exporter==0.2.2
+prometheus-client==0.3.1


### PR DESCRIPTION
This makes a few changes:

- Aggregates metrics across gunicorn workers
- Blocks access to /metrics in Nginx (another change on the ALB must occur)
- Adds new pip package for Prometheus
- Disables the Prometheus exporter (I need to work out some other issues)



> Note in order to land a PR you must conform to the requirements outlined in https://github.com/mozilla-iam/mozilla-iam/blob/master/GitHub-Security-Settings.md

Branch Protection Rules on master, and production branches are set as follows:
    Protect this branch
    Require pull request reviews before merging
    Require signed commits
    Include administrators
    Restrict who can push to this branch
        Include the teams which should be able to affect code (i.e. write, commit, push code)
        Do NOT include the teams that may not (such as issue managers, bots, etc.)

NOTE: "Restrict who can push to this branch" is effectively the control by which you may allow specific teams to write issues without being able to change code. This does not prevent these teams from contributing through pull-requests. It prevents these teams from merging code.