### PR TITLE
Support new rules error messages: staffmustuseldap, aai_failed

### DIFF
--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -161,6 +161,15 @@ class tokenVerification(object):
                 connection_name=self._get_connection_name(self.jws_data.get('connection', '')),
                 preferred_connection_name=self._get_connection_name(self.preferred_connection_name)
             )
+        elif error_code == 'aai_failed':
+            error_text = "{client} requires you to setup additional security measure for your account, \
+            such as enabling multi-factor authentication (MFA) or using a safer authentication method (such as a \
+            Firefox Account login). You will not be able to login until this is \
+            done.".format(client=self.data.get('client'))
+        elif error_code == 'staffmustuseldap':
+            error_text = "Staff LDAP accounts holders are required to use their LDAP account to login. Please go back \
+            and type your LDAP email to login with your Staff account, instead of using
+            {connection_name}.".format(connection_name=self._get_connection_name(self.jws_data.get('connection', '')))
         else:
             error_text = "Oye, something went wrong."
         return error_text


### PR DESCRIPTION
Note: this may move to NLX in the future, but this allows messages to be displayed the standard way in the mean time.

The wording of the aai message is quite delicate to get right (especially until the NLX side/UX makes it so that errors don't need to be shown often), so feel free to directly change it if you have better ideas