### PR TITLE
Changed FxA+2FA setup link

### DIFF
--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -137,9 +137,8 @@ class tokenVerification(object):
                 </a> to setup your device, then try logging in again."
         elif error_code == 'fxarequiremfa':
             error_text = \
-                "You must setup a security device (\"MFA"", \"2FA\") for your Firefox Account in order to access \
-                this service. Please setup a <a href=\"https://accounts.firefox.com\">security device</a>, then \
-                try logging in again.\n<br/><br/>\n\
+                "Please <a href=\"https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication\">secure your Firefox Account with two-step authentication</a>, \
+                then try logging in again.\n<br/><br/>\n\
                 If you have just setup your security device and you see this message, please log out of \
                  <a href=\"https://accounts.firefox.com\">Firefox Accounts</a> (click the \"Sign out\" button), then \
                  log back in."


### PR DESCRIPTION
Based on feedback from @davismtl:
Changing FxA+2FA setup URL to the corresponding SUMO article.

## Requirements for PRs to the SSO-Dashboard.

> Note in order to land a PR you must conform to the requirements outlined in https://github.com/mozilla-iam/mozilla-iam/blob/master/GitHub-Security-Settings.md

Branch Protection Rules on master, and production branches are set as follows:
    Protect this branch
    Require pull request reviews before merging
    Require signed commits
    Include administrators
    Restrict who can push to this branch
        Include the teams which should be able to affect code (i.e. write, commit, push code)
        Do NOT include the teams that may not (such as issue managers, bots, etc.)

NOTE: "Restrict who can push to this branch" is effectively the control by which you may allow specific teams to write issues without being able to change code. This does not prevent these teams from contributing through pull-requests. It prevents these teams from merging code.
