### PR TITLE
Force https scheme for CSP policy values

### DIFF
--- a/dashboard/csp.py
+++ b/dashboard/csp.py
@@ -2,8 +2,8 @@ DASHBOARD_CSP = {
     "default-src": ["'self'"],
     "script-src": [
         "'self'",
-        "ajax.googleapis.com",
-        "fonts.googleapis.com",
+        "https://ajax.googleapis.com",
+        "https://fonts.googleapis.com",
         "https://*.googletagmanager.com",
         "https://tagmanager.google.com",
         "https://*.google-analytics.com",
@@ -12,8 +12,8 @@ DASHBOARD_CSP = {
     ],
     "style-src": [
         "'self'",
-        "ajax.googleapis.com",
-        "fonts.googleapis.com",
+        "https://ajax.googleapis.com",
+        "https://fonts.googleapis.com",
         "https://cdn.sso.mozilla.com",
         "https://cdn.sso.allizom.org",
     ],
@@ -29,8 +29,8 @@ DASHBOARD_CSP = {
     ],
     "font-src": [
         "'self'",
-        "fonts.googleapis.com",
-        "fonts.gstatic.com",
+        "https://fonts.googleapis.com",
+        "https://fonts.gstatic.com",
         "https://cdn.sso.mozilla.com",
         "https://cdn.sso.allizom.org",
     ],


### PR DESCRIPTION
In the context of an XSS issue, where an attacker has gained control over JS in the context of this site, it could be possible for the attacker to force the browser to make http:// requests to 
ajax.googleapis.com, fonts.googleapis.com, and fonts.gstatic.com for various content, including script loads.

An attacker may wish to do this for a number of reasons:

1.) To leak secret material between those domains (unlikely in this specific context)
2.) To further compromise the integrity of JS load and chain that to gain full JS execution loaded over HTTP via MiTM attack.

I think this just helps us become more explicit that that "though shall load all CSP controlled content via HTTPS".

**WARNING**: I am not a sso dashboard developer, and this is just a good will type PR, please do test this thoroughly before merging.