### PR TITLE
Migrate API version to latest

### DIFF
--- a/k8s/templates/deployment.yaml
+++ b/k8s/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}


### PR DESCRIPTION
Kubernetes 1.16 deprecates `extensions/v1beta1` used in this deployment