### PR TITLE
Comment out code calling cisv1 person api endpoint

### DIFF
--- a/dashboard/person.py
+++ b/dashboard/person.py
@@ -1,6 +1,8 @@
 import http.client
 import json
-import urllib
+# Commenting out in since CISv1 is no longer up and running
+# todo: this will need to get modified to reach out to person api v2
+# import urllib
 
 from dashboard import config
 
@@ -34,17 +36,20 @@ class API(object):
         return json.loads(data.decode("utf-8"))
 
     def get_userinfo(self, auth_zero_id):
-        user_id = urllib.parse.quote(auth_zero_id)
-        conn = http.client.HTTPSConnection("{}".format(self.person_api_url))
-        token = "Bearer {}".format(self.get_bearer().get("access_token"))
+        return
+        # # Commenting out in since CISv1 is no longer up and running
+        # # todo: this will need to get modified to reach out to person api v2
+        # user_id = urllib.parse.quote(auth_zero_id)
+        # conn = http.client.HTTPSConnection("{}".format(self.person_api_url))
+        # token = "Bearer {}".format(self.get_bearer().get("access_token"))
 
-        headers = {"authorization": token}
+        # headers = {"authorization": token}
 
-        conn.request("GET", "/v1/profile/{}".format(user_id), headers=headers)
+        # conn.request("GET", "/v1/profile/{}".format(user_id), headers=headers)
 
-        res = conn.getresponse()
-        data = res.read()
-        return json.loads(json.loads(data.decode("utf-8")).get("body"))
+        # res = conn.getresponse()
+        # data = res.read()
+        # return json.loads(json.loads(data.decode("utf-8")).get("body"))
 
     def _get_url(self):
         if self.config.OIDC_DOMAIN == "auth.mozilla.auth0.com":


### PR DESCRIPTION
Since CISv1 is actively being deprecated, we comment out the call to /v1/profile (which eventually gets routed to CISv1). As the caller is wrapped with an except (https://github.com/mozilla-iam/sso-dashboard/blob/master/dashboard/app.py#L188-L197), the app still loads. This problem surfaces when you click on the upper right hand nav dropdown, where a "Name" and an avatar used to be displayed (https://github.com/mozilla-iam/sso-dashboard/blob/master/dashboard/templates/dashboard.html#L39-L43)

We'll need to update this function to reach out to the /v2 equivalent route in the person api.