### PR TITLE
bug 1543424 - enforce https redirection (fixes #414)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -66,7 +66,7 @@ if (
         )
     )
 
-talisman = Talisman(app, content_security_policy=DASHBOARD_CSP, force_https=False)
+talisman = Talisman(app, content_security_policy=DASHBOARD_CSP, force_https=True)
 
 app.config.from_object(config.Config(app).settings)
 app_list = S3Transfer(config.Config(app).settings)


### PR DESCRIPTION
After various back & forth with SRE (in https://bugzilla.mozilla.org/show_bug.cgi?id=1543424), it seems this ought to be fixed within the app.

I haven't been involved with SSO/IAM stuff, but observed that errors on the Firefox side came up more often than not (due to HTTPS-Only mode), so I don't have full confidence in this patch.
Do we have some sort of staging to test this?  Paging @gene1wood 