### PR TITLE
Fix up setup-codebuild with helm binary that is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ all:
 setup-codebuild:
 	curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/darwin/amd64/kubectl
 	chmod +x kubectl
-	curl -O https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
-	tar zxf helm-v2.11.0-linux-amd64.tar.gz
+	curl -O https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz
+	tar zxf helm-v3.7.0-linux-amd64.tar.gz
 	mv linux-amd64/helm /usr/local/bin/
 	curl -O https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
 	chmod +x aws-iam-authenticator


### PR DESCRIPTION
Point at new Helm binary install location and upgrade Helm to get CodeBuild to work.
```bash
$ curl https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz                                                                                                                                                                                                                                                                                                                                                          
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist.</Message></Error>
```
