### PR TITLE
Remove app name truncation

### DIFF
--- a/dashboard/op/yaml_loader.py
+++ b/dashboard/op/yaml_loader.py
@@ -30,7 +30,6 @@ class Application(object):
     def _render_data(self):
         for app in self.apps["apps"]:
             app["application"]["alt_text"] = app["application"]["name"]
-            app["application"]["name"] = self._truncate(app["application"]["name"])
 
     def _alphabetize(self):
         self.apps["apps"].sort(key=lambda a: a["application"]["name"].lower())
@@ -46,12 +45,6 @@ class Application(object):
             return True
         except Exception:
             return False
-
-    def _truncate(self, app_name):
-        """If name is longer than allowed 18 chars truncate the name."""
-        app_name = (app_name[:16] + "..") if len(app_name) > 18 else app_name
-
-        return app_name
 
     def vanity_urls(self):
         redirects = []

--- a/dashboard/static/css/base.scss
+++ b/dashboard/static/css/base.scss
@@ -1,3 +1,8 @@
+:root {
+    --logo-width: 130px;
+    --logo-padding: 10px;
+    --logo-border: 1px;
+}
 @font-face {
     font-family: 'Open Sans';
     font-weight: normal;
@@ -526,18 +531,18 @@ body {
 
             .app-logo {
                 background-color: white;
-                border: 1px solid $lightgray;
-                padding: 10px;
-                width: 130px;
-                height: 130px;
+                border: var(--logo-border) solid $lightgray;
+                padding: var(--logo-padding);
+                width: var(--logo-width);
+                height: var(--logo-width);
                 display: table-cell;
                 vertical-align: middle;
 
                 img {
                     display: block;
                     margin: 0 auto;
-                    max-width: 120px;
-                    max-height: 120px;
+                    max-width: calc(var(--logo-width) - 10px);
+                    max-height: calc(var(--logo-width) - 10px);
                 }
 
                 &.yellow-border {
@@ -548,6 +553,10 @@ body {
             .app-name {
                 color: black;
                 margin: 10px 0;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                overflow: hidden;
+                width: calc(var(--logo-width) + (var(--logo-padding) * 2) + (var(--logo-border) * 2));
             }
         }
     }

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -127,7 +127,7 @@
           <div class="mui--text-center app-logo">
             <img src="{{ config.CDN }}/images/{{ app['application']['logo'] }}" role="presentation" alt="">
           </div>
-          <p class="mui--text-center app-name">{{ app['application']['name'] }}</p>
+          <p class="mui--text-center app-name" title="{{ app['application']['name'] }}">{{ app['application']['name'] }}</p>
         </a>
       </li>
     {% endfor %}


### PR DESCRIPTION
This changes the SSO Dashboard behavior to stop truncating app names.
Instead this
* leaves the full app name intact (for accessibility)
* achieves the visual truncation through CSS
* adds a tooltip to the name with the full value

This will improve accessibility and allow users to see the full name of the app without affecting the grid layout. Without this change, it's impossible for users to determine the full name of an app that is over 18 characters long (by any means). The data just isn't there.

This is what it looks like with this change

![Selection_312](https://user-images.githubusercontent.com/1134034/138774916-8087645c-b3ec-454e-9bfe-ff8369996fd1.png)

and this is what it looks like while being mouseovered showing the tooltip

![Selection_313](https://user-images.githubusercontent.com/1134034/138775157-c3ad3763-faf7-46b2-8c1d-6b65b6453048.png)


