### PR TITLE
Add logic to login to Docker Hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ setup-codebuild:
 
 .PHONY: login
 login:
+	$(eval DOCKER_ID := $(shell aws --region us-west-2 ssm get-parameter --name "/iam/sso-dashboard/$(STAGE)/docker_user_id" --query 'Parameter.Value' --output text))
+	$(eval DOCKER_ACCESS_TOKEN := $(shell aws --region us-west-2 ssm get-parameter --name "/iam/sso-dashboard/$(STAGE)/docker_access_token" --query 'Parameter.Value' --output text))
+	echo $(DOCKER_ACCESS_TOKEN) | docker login --username $(DOCKER_ID) --password-stdin
 	aws --region us-west-2 eks update-kubeconfig --name $(CLUSTER_NAME)
 	aws ecr get-login --region us-west-2 --no-include-email | bash
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ setup-codebuild:
 .PHONY: login
 login:
 	$(eval DOCKER_ID := $(shell aws --region us-west-2 ssm get-parameter --name "/iam/sso-dashboard/$(STAGE)/docker_user_id" --query 'Parameter.Value' --output text))
-	$(eval DOCKER_ACCESS_TOKEN := $(shell aws --region us-west-2 ssm get-parameter --name "/iam/sso-dashboard/$(STAGE)/docker_access_token" --query 'Parameter.Value' --output text))
+	$(eval DOCKER_ACCESS_TOKEN := $(shell aws --region us-west-2 ssm get-parameter --name "/iam/sso-dashboard/$(STAGE)/docker_access_token" --with-decryption --query 'Parameter.Value' --output text))
 	echo $(DOCKER_ACCESS_TOKEN) | docker login --username $(DOCKER_ID) --password-stdin
 	aws --region us-west-2 eks update-kubeconfig --name $(CLUSTER_NAME)
 	aws ecr get-login --region us-west-2 --no-include-email | bash


### PR DESCRIPTION
This pulls a Docker ID and access token from SSM Parameter store for a dedicated
Docker user and logs in as that user to Docker Hub. This works around the issue
where anonymous API access to Docker Hub from AWS CodeBuild IP addresses results
in rate limiting the docker pulls of the Docker Base Image (e.g. centos)

Fixes #446

I haven't tested this as it's a CI fix but hopefully it works.