### PR TITLE
chore(k8s): Migrate off beta apis

### DIFF
--- a/k8s/templates/ingress-controller.yaml
+++ b/k8s/templates/ingress-controller.yaml
@@ -20,7 +20,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx-ingress-role
@@ -69,7 +69,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding

--- a/k8s/templates/ingress.yaml
+++ b/k8s/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   annotations:

--- a/k8s/templates/ingress.yaml
+++ b/k8s/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -17,8 +17,9 @@ spec:
   - host: {{ .Values.domain_name }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .Values.name }}
-          servicePort: 8000
-        path: /
-
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          name: {{ .Values.name }}
+          port:
+            number: 8000


### PR DESCRIPTION
```
Ingress                          sso-dashboard-prod   sso-dashboard                                        extensions/v1beta1                     networking.k8s.io/v1 (1.19.0)
Ingress                          sso-dashboard-dev    sso-dashboard                                        extensions/v1beta1                     networking.k8s.io/v1 (1.19.0)
Role                             sso-dashboard-dev    nginx-ingress-role                                   rbac.authorization.k8s.io/v1beta1      rbac.authorization.k8s.io/v1 (1.8.0)
Role                             sso-dashboard-prod   nginx-ingress-role                                   rbac.authorization.k8s.io/v1beta1      rbac.authorization.k8s.io/v1 (1.8.0)
RoleBinding                      sso-dashboard-dev    nginx-ingress-role-nisa-binding                      rbac.authorization.k8s.io/v1beta1      rbac.authorization.k8s.io/v1 (1.8.0)
RoleBinding                      sso-dashboard-prod   nginx-ingress-role-nisa-binding                      rbac.authorization.k8s.io/v1beta1      rbac.authorization.k8s.io/v1 (1.8.0)
```