### PR TITLE
Activate tile link on searchbox enter key if only one visible

### DIFF
--- a/dashboard/static/js/base.js
+++ b/dashboard/static/js/base.js
@@ -2,7 +2,8 @@ $(document).ready(function(){
     'use strict';
 
     // This is the js that powers the search box
-    $(':input[name=filter]').on('input', function() {
+    $(':input[name=filter]')
+    .on('input', function() {
         // Get value just typed into textbox -- see .toLowerCase()
         var val = this.value.toLowerCase();
 
@@ -22,6 +23,15 @@ $(document).ready(function(){
             })
             // Fade those out
             .fadeOut();
+    })
+    .on('keypress', function (ev) {
+        if (ev.key === 'Enter') {
+            const tiles = $('#app-grid .app-tile:visible');
+            if (tiles.length === 1) {
+                // If only one tile is visible, open its link on Enter
+                window.open(tiles[0].href, '_blank');
+            }
+        }
     });
 
     // Search input: Highlight, Align, Focus


### PR DESCRIPTION
This PR adds an event handler for the `Enter` key being pressed in the search box while only one tile is visible. When that happens, the tile's link is opened in a new tab, just as would happen if the tile were clicked manually.

I also tried to make the tiles tabbable, but couldn't figure out why they aren't.