### PR TITLE
Update notingroup error message

### DIFF
--- a/dashboard/oidc_auth.py
+++ b/dashboard/oidc_auth.py
@@ -114,7 +114,8 @@ class tokenVerification(object):
                  log back in.'
         elif error_code == "notingroup":
             error_text = "Sorry, you do not have permission to access {client}.  \
-            Please contact eus@mozilla.com if you should have access.".format(
+            Please contact the application owner for access.  If unsure who that \
+            may be, please contact ServiceDesk@mozilla.com for support.".format(
                 client=self.data.get("client")
             )
         elif error_code == "accesshasexpired":


### PR DESCRIPTION
This PR stems from a slack request from csmith to better redirect users for assistance when a user is not in an application access group.