### PR TITLE
Gcp logging

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,5 +1,4 @@
 """SSO Dashboard App File."""
-import google.cloud.logging
 import json
 import logging.config
 import mimetypes
@@ -39,7 +38,6 @@ from dashboard.models.alert import FakeAlert
 from dashboard.models.alert import Rules
 from dashboard.models.tile import S3Transfer
 
-from google.cloud.logging_v2.handlers import CloudLoggingHandler
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -48,11 +46,7 @@ with open("dashboard/logging.yml", "r") as log_config:
     config_dict = yaml.safe_load(config_yml)
     logging.config.dictConfig(config_dict)
 
-gcp_logger_client = google.cloud.logging.Client()
-gcp_handler = CloudLoggingHandler(gcp_logger_client)
-
 logger = logging.getLogger("sso-dashboard")
-logger.addHandler(gcp_handler)
 
 app = Flask(__name__)
 everett_config = get_config()

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -39,7 +39,7 @@ from dashboard.models.alert import Rules
 from dashboard.models.tile import S3Transfer
 
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 with open("dashboard/logging.yml", "r") as log_config:
     config_yml = log_config.read()

--- a/dashboard/logging.yml
+++ b/dashboard/logging.yml
@@ -1,5 +1,6 @@
 # Default AWS Config
 version: 1
+disable_existing_loggers: False
 formatters:
     json:
         format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ Flask-pyoidc==3.13.0
 flask-talisman==1.0.0
 future==0.18.3
 gevent==22.10.2
-google-cloud-logging>=3.0.0
 greenlet==2.0.2
 gunicorn==20.1.0
 identify==2.5.24


### PR DESCRIPTION
This PR reverts the previous addition of the gcp cloud logger and simply keeps the default logger active.  This allows all logging to pipe to stdout/stderr where cloudrun will send it to gcp logging.  Keeping the default logger active allows traceback stacks to be logged also.