### PR TITLE
Update Flask-pyoidc 3.13.0->3.14.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+annotated-types==0.5.0
 async-timeout==4.0.2
 Beaker==1.12.1
 boto3==1.26.142
@@ -22,7 +23,7 @@ filelock==3.12.1
 Flask==2.2.5
 Flask-Assets==2.0
 Flask-KVSession==0.6.2
-Flask-pyoidc==3.13.0
+Flask-pyoidc==3.14.3
 flask-talisman==1.0.0
 future==0.18.3
 gevent==22.10.2
@@ -41,7 +42,7 @@ Mako==1.2.4
 MarkupSafe==2.1.2
 moto==4.1.10
 nodeenv==1.8.0
-oic==1.4.0
+oic==1.6.1
 packaging==23.1
 platformdirs==3.5.3
 pluggy==1.0.0
@@ -49,10 +50,14 @@ pre-commit==2.21.0
 pyasn1==0.5.0
 pycparser==2.21
 pycryptodomex==3.18.0
+pydantic==2.5.2
+pydantic-settings==2.0.3
+pydantic_core==2.14.5
 pyjwkest==1.4.2
 pyOpenSSL==23.1.1
 pyproject_api==1.5.1
 python-dateutil==2.8.2
+python-dotenv==0.21.1
 python-jose==3.3.0
 PyYAML==6.0
 redis==4.5.5


### PR DESCRIPTION
This PR updates the Flask-pyoidc from 3.13.0 to 3.14.3.  This new version includes fixes [1] that better handles the OIDC work flow for Flask apps that reside behind firewalls and therefore likely are internally serving `http` from the backend.

[1] https://github.com/zamzterz/Flask-pyoidc/pull/169