### PR TITLE
Disable the alert and notification engine

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -181,8 +181,9 @@ def dashboard():
     # Transfer any updates in to the app_tiles.
     S3Transfer(config.Config(app).settings).sync_config()
 
+    # The rule engine has been disabled.  See IAM-1256
     # Send the user session and browser headers to the alert rules engine.
-    Rules(userinfo=session["userinfo"], request=request).run()
+    # Rules(userinfo=session["userinfo"], request=request).run()
 
     user = User(session, config.Config(app).settings)
     apps = user.apps(Application(app_list.apps_yml).apps)


### PR DESCRIPTION
This is the beginning of the end for Alerts and Notifications in the SSO Dashboard.  This single commit disables the execution of the Rule engine.   There will be more PRs to follow that will gut the Rule engine itself to fully remove Alerts and Notifications related code from the SSO dashboard.  The intent to return the dashboard to a simple app tile display for users.

See IAM-1256