### PR TITLE
Adjust gunicorn settings and ensure tracebacks propagate up to logs

### DIFF
--- a/clouddeploy/sso-dashboard-dev.template.yaml
+++ b/clouddeploy/sso-dashboard-dev.template.yaml
@@ -47,6 +47,8 @@ spec:
           - '--timeout=60'
           - '--log-level=debug'
           - '--error-logfile=-'
+          - '--reload'
+          - '--reload-extra-file=/dashboard/data/apps.yml'
         ports:
           - name: http1
             containerPort: 8000

--- a/clouddeploy/sso-dashboard-dev.template.yaml
+++ b/clouddeploy/sso-dashboard-dev.template.yaml
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: '1'
-        autoscaling.knative.dev/maxScale: '3'
+        autoscaling.knative.dev/minScale: '0'
+        autoscaling.knative.dev/maxScale: '1'
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/vpc-access-connector: 'redis-connector'
@@ -41,7 +41,12 @@ spec:
           - '--bind'
           - '0.0.0.0:8000'
           - '--workers=2'
+          - '--max-requests=1000'
+          - '--max-requests-jitter=50'
+          - '--graceful-timeout=30'
+          - '--timeout=60'
           - '--log-level=debug'
+          - '--error-logfile=-'
         ports:
           - name: http1
             containerPort: 8000

--- a/clouddeploy/sso-dashboard-prod.template.yaml
+++ b/clouddeploy/sso-dashboard-prod.template.yaml
@@ -47,6 +47,8 @@ spec:
           - '--timeout=60'
           - '--log-level=debug'
           - '--error-logfile=-'
+          - '--reload'
+          - '--reload-extra-file=/dashboard/data/apps.yml'
         ports:
           - name: http1
             containerPort: 8000

--- a/clouddeploy/sso-dashboard-prod.template.yaml
+++ b/clouddeploy/sso-dashboard-prod.template.yaml
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: '1'
-        autoscaling.knative.dev/maxScale: '3'
+        autoscaling.knative.dev/minScale: '0'
+        autoscaling.knative.dev/maxScale: '2'
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/vpc-access-connector: 'redis-connector'
@@ -41,7 +41,12 @@ spec:
           - '--bind'
           - '0.0.0.0:8000'
           - '--workers=2'
+          - '--max-requests=1000'
+          - '--max-requests-jitter=50'
+          - '--graceful-timeout=30'
+          - '--timeout=60'
           - '--log-level=debug'
+          - '--error-logfile=-'
         ports:
           - name: http1
             containerPort: 8000

--- a/clouddeploy/sso-dashboard-staging.template.yaml
+++ b/clouddeploy/sso-dashboard-staging.template.yaml
@@ -47,6 +47,8 @@ spec:
           - '--timeout=60'
           - '--log-level=debug'
           - '--error-logfile=-'
+          - '--reload'
+          - '--reload-extra-file=/dashboard/data/apps.yml'
         ports:
           - name: http1
             containerPort: 8000

--- a/clouddeploy/sso-dashboard-staging.template.yaml
+++ b/clouddeploy/sso-dashboard-staging.template.yaml
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: '1'
-        autoscaling.knative.dev/maxScale: '3'
+        autoscaling.knative.dev/minScale: '0'
+        autoscaling.knative.dev/maxScale: '1'
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/vpc-access-connector: 'redis-connector'
@@ -41,7 +41,12 @@ spec:
           - '--bind'
           - '0.0.0.0:8000'
           - '--workers=2'
+          - '--max-requests=1000'
+          - '--max-requests-jitter=50'
+          - '--graceful-timeout=30'
+          - '--timeout=60'
           - '--log-level=debug'
+          - '--error-logfile=-'
         ports:
           - name: http1
             containerPort: 8000

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -23,6 +23,8 @@ class DefaultConfig(object):
 
     DEBUG = bool(CONFIG("debug", namespace="sso-dashboard", default="True"))
     TESTING = bool(CONFIG("testing", namespace="sso-dashboard", default="False"))
+    PROPAGATE_EXCEPTIONS = bool(CONFIG("propagate_exceptions", namespace="sso-dashboard", default="True"))
+
     CSRF_ENABLED = bool(CONFIG("csrf_enabled", default="True"))
     PERMANENT_SESSION = bool(CONFIG("permanent_session", namespace="sso-dashboard", default="True"))
     seconds = int(CONFIG("permanent_session_lifetime", namespace="sso-dashboard", default="86400"))


### PR DESCRIPTION
This PR adjusts the gunicorn and flask app settings to ensure traceroutes make it into the cloud run logs.  This also sets gunicorn workers to exit after a max number of requests and reload when apps.yml is updated.