### PR TITLE
Fix app.env that was causing 500 error on / route

### DIFF
--- a/clouddeploy/sso-dashboard-dev.template.yaml
+++ b/clouddeploy/sso-dashboard-dev.template.yaml
@@ -88,7 +88,7 @@ spec:
           - name: AWS_DEFAULT_REGION
             value: us-west-2
           - name: ENVIRONMENT
-            value: Staging
+            value: development
           - name: MOZILLIANS_API_URL
             value: https://mozillians.org/api/v2/users/
           - name: DASHBOARD_GUNICORN_WORKERS

--- a/clouddeploy/sso-dashboard-prod.template.yaml
+++ b/clouddeploy/sso-dashboard-prod.template.yaml
@@ -88,7 +88,7 @@ spec:
           - name: AWS_DEFAULT_REGION
             value: us-west-2
           - name: ENVIRONMENT
-            value: Prod
+            value: production
           - name: MOZILLIANS_API_URL
             value: https://mozillians.org/api/v2/users/
           - name: DASHBOARD_GUNICORN_WORKERS

--- a/clouddeploy/sso-dashboard-staging.template.yaml
+++ b/clouddeploy/sso-dashboard-staging.template.yaml
@@ -88,7 +88,7 @@ spec:
           - name: AWS_DEFAULT_REGION
             value: us-west-2
           - name: ENVIRONMENT
-            value: Prod
+            value: staging
           - name: MOZILLIANS_API_URL
             value: https://mozillians.org/api/v2/users/
           - name: DASHBOARD_GUNICORN_WORKERS

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -88,7 +88,7 @@ def favicon():
 
 @app.route("/")
 def home():
-    if app.env == "development":
+    if config.Config(app).environment == "local":
         return redirect("dashboard", code=302)
 
     url = request.url.replace("http://", "https://", 1)

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -11,7 +11,7 @@ class Config(object):
     def __init__(self, app):
         self.app = app
 
-        self.environment = CONFIG("environment", default="development")
+        self.environment = CONFIG("environment", default="local")
         self.settings = self._init_env()
 
     def _init_env(self):


### PR DESCRIPTION
        Flask removed FLASK_ENV in v2.3.0 which was being checked on
        the root flask route. (Thanks gcox!)
        This commit fixes the environment varible for the seperate
        environments and fixes where the variable is being sourced.

See: https://flask.palletsprojects.com/en/3.0.x/changes/#version-2-3-0