### PR TITLE
Fix existing tests, pre-commit, and Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pre-commit
+          pip install pre-commit tox
 
       - name: Run pre-commit
         run: pre-commit run --all-files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,18 @@ jobs:
           STATUS_TITLE: Linting/Unittesting
           STATUS_VALUE: ':link-run: *Running*'
 
-      - name: Install tox
-        run: pip install tox
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
-      - name: Running Tox
-        run: tox
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files
 
   build:
     name: Building

--- a/.github/workflows/pull_requests_only.yml
+++ b/.github/workflows/pull_requests_only.yml
@@ -1,0 +1,30 @@
+name: PR Linting / Unit Testing
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: 'read'
+
+jobs:
+  lint:
+    name: Linting / Unit Testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/pull_requests_only.yml
+++ b/.github/workflows/pull_requests_only.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pre-commit
+          pip install pre-commit tox
 
       - name: Run pre-commit
         run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,19 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
         args: [--allow-multiple-documents]
-
     -   id: check-added-large-files
 
--   repo: https://github.com/psf/black
-    rev: 22.10.0
+  - repo: local
     hooks:
-    -   id: black
+      - id: run-tox
+        name: Run tox tests
+        entry: tox
+        language: system
+        pass_filenames: false

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -4,15 +4,20 @@ import os
 import dashboard.models.user as user
 
 
-class TestUser(object):
-    def setup(self):
-        self.fixture_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data/userinfo.json")
+class TestUser:
+    def setup_method(self):
+        try:
+            self.fixture_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data/userinfo.json")
+            with open(self.fixture_file) as f:
+                self.session_fixture = json.load(f)
 
-        self.session_fixture = json.loads(open(self.fixture_file).read())
-        self.good_apps_list = {"apps": []}
+            self.good_apps_list = {"apps": []}
 
-        self.u = user.User(session=self.session_fixture, app_config=None)
-        self.u.api_token = "foo"
+            self.u = user.User(session=self.session_fixture, app_config=None)
+            self.u.api_token = "foo"
+        except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
+            self.u = None
+            raise RuntimeError(f"Failed to set up TestUser: {str(e)}")
 
     def test_object_init(self):
         assert self.u is not None

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 env_list =
     eslint, lint, py312
 minversion = 4.6.0
+skip_missing_interpreters = false
 
 [testenv]
 description = run the tests with pytest


### PR DESCRIPTION
        Here we do the following:
        * Make tox fail on missing interperters.
        * Fix the TestUser test so the setup method handles errors and
          initializes properly before the test.
        * Instead of running black on pre-commit, we now run tox
          locally which includes all linting and test suites include
          black.  This now ensures the same linting and test that run
          in Github Actions are executed locally before a commit.  In
          addition, we run pre-commit in GHA so all linting and testing
          is identical between what is run locally and in GHA.
        * Fixed the existing main.yml GHA so the python 3.12 is set up
          for tox to use.  This fixes the missing interperter issue that
          was causing the skipped tox tests in the first place.
        * Added a new GHA that only runs linting/tests on RPs.  This
          will help catch things before landing on master.

        Note:  README.md and other docs will be overhauled soon in a
        future PR which will reflect these changes and many other
        changes that have been landed without being documented.