### PR TITLE
Increase Min/Max cloud run instances

### DIFF
--- a/clouddeploy/sso-dashboard-dev.template.yaml
+++ b/clouddeploy/sso-dashboard-dev.template.yaml
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: '0'
-        autoscaling.knative.dev/maxScale: '1'
+        autoscaling.knative.dev/minScale: '1'
+        autoscaling.knative.dev/maxScale: '3'
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/vpc-access-connector: 'redis-connector'
@@ -40,9 +40,7 @@ spec:
           - gevent
           - '--bind'
           - '0.0.0.0:8000'
-          - '--workers=2'
-          - '--max-requests=1000'
-          - '--max-requests-jitter=50'
+          - '--workers=3'
           - '--graceful-timeout=30'
           - '--timeout=60'
           - '--log-level=debug'
@@ -89,10 +87,6 @@ spec:
             value: us-west-2
           - name: ENVIRONMENT
             value: development
-          - name: MOZILLIANS_API_URL
-            value: https://mozillians.org/api/v2/users/
-          - name: DASHBOARD_GUNICORN_WORKERS
-            value: 2
           - name: FLASK_DEBUG
             value: False
           - name: DEBUG

--- a/clouddeploy/sso-dashboard-prod.template.yaml
+++ b/clouddeploy/sso-dashboard-prod.template.yaml
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: '0'
-        autoscaling.knative.dev/maxScale: '2'
+        autoscaling.knative.dev/minScale: '2'
+        autoscaling.knative.dev/maxScale: '3'
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/vpc-access-connector: 'redis-connector'
@@ -40,9 +40,7 @@ spec:
           - gevent
           - '--bind'
           - '0.0.0.0:8000'
-          - '--workers=2'
-          - '--max-requests=1000'
-          - '--max-requests-jitter=50'
+          - '--workers=3'
           - '--graceful-timeout=30'
           - '--timeout=60'
           - '--log-level=debug'
@@ -89,10 +87,6 @@ spec:
             value: us-west-2
           - name: ENVIRONMENT
             value: production
-          - name: MOZILLIANS_API_URL
-            value: https://mozillians.org/api/v2/users/
-          - name: DASHBOARD_GUNICORN_WORKERS
-            value: 2
           - name: FLASK_DEBUG
             value: False
           - name: DEBUG

--- a/clouddeploy/sso-dashboard-staging.template.yaml
+++ b/clouddeploy/sso-dashboard-staging.template.yaml
@@ -23,8 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: '0'
-        autoscaling.knative.dev/maxScale: '1'
+        autoscaling.knative.dev/minScale: '2'
+        autoscaling.knative.dev/maxScale: '3'
         run.googleapis.com/cpu-throttling: 'false'
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/vpc-access-connector: 'redis-connector'
@@ -40,9 +40,7 @@ spec:
           - gevent
           - '--bind'
           - '0.0.0.0:8000'
-          - '--workers=2'
-          - '--max-requests=1000'
-          - '--max-requests-jitter=50'
+          - '--workers=3'
           - '--graceful-timeout=30'
           - '--timeout=60'
           - '--log-level=debug'
@@ -89,10 +87,6 @@ spec:
             value: us-west-2
           - name: ENVIRONMENT
             value: staging
-          - name: MOZILLIANS_API_URL
-            value: https://mozillians.org/api/v2/users/
-          - name: DASHBOARD_GUNICORN_WORKERS
-            value: 2
           - name: FLASK_DEBUG
             value: False
           - name: DEBUG


### PR DESCRIPTION
        Recently, the Min/Max cloud run instances had been reduced in
        an attempt to fix the failure causing the stale apps.yml data.
        This commit increases the min instances to 1 for dev and 2 for
        staging and prod.  The max is set to 3 for all 3 environments.

        This also adjusts the gunicorn async workers to 3 which is based
        on the fact, instances for all environments are set to 1vCpu.
        Where n = vCpus, we get 2n + 1 as a basis for setting the
        workers.  This can be adjust in the future if we ever change the
        number of vCpus per instance.

        Other things:
        * Remove some unused ENVs
        * Remove max-requests and max-requests-jitter