### PR TITLE
ci Don't always re-install dependencies, which speeds up successive builds

### DIFF
--- a/ci/node-install.sh
+++ b/ci/node-install.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
+# Meant to be used with tox. Probably don't use this normally.
+
 set -eu
 
-if [ -f "$TOX_ENV_DIR/bin/node" ]; then
-    echo Node and friends already installed.
-    npm ci
-    exit 0
+# If node isn't installed, install it using nodeenv (along with npm).
+if [ ! -f "$TOX_ENV_DIR/bin/node" ] || [ "$("$TOX_ENV_DIR/bin/node" --version)" != "v$NODE_VERSION" ]; then
+    nodeenv --prebuilt -p --node "$NODE_VERSION" --with-npm --npm "$NPM_VERSION" "$TOX_ENV_DIR"
 fi
 
-nodeenv --prebuilt -p --node "$NODE_VERSION" "$TOX_ENV_DIR"
-npm install -g "npm@$NPM_VERSION"
+# Ensure npm is the version we want.
+if [ "$("$TOX_ENV_DIR/bin/npm" --version)" != "$NPM_VERSION" ]; then
+    npm install -g "npm@$NPM_VERSION"
+fi
+
 npm ci

--- a/ci/node-install.sh
+++ b/ci/node-install.sh
@@ -3,9 +3,10 @@ set -eu
 
 if [ -f "$TOX_ENV_DIR/bin/node" ]; then
     echo Node and friends already installed.
+    npm ci
     exit 0
 fi
 
-nodeenv --prebuilt -p --node 18.20.4 "$TOX_ENV_DIR"
-npm install -g npm@latest
+nodeenv --prebuilt -p --node "$NODE_VERSION" "$TOX_ENV_DIR"
+npm install -g "npm@$NPM_VERSION"
 npm ci

--- a/ci/node-install.sh
+++ b/ci/node-install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+if [ -f "$TOX_ENV_DIR/bin/node" ]; then
+    echo Node and friends already installed.
+    exit 0
+fi
+
+nodeenv --prebuilt -p --node 18.20.4 "$TOX_ENV_DIR"
+npm install -g npm@latest
+npm ci

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Mozilla SSO dashboard",
     "repository": {
         "type": "git",
-        "url": "hhttps://github.com/mozilla-iam/sso-dashboard"
+        "url": "https://github.com/mozilla-iam/sso-dashboard"
     },
     "author": "Mozilla",
     "license": "MPLv2",

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ skip_missing_interpreters = false
 description = base environment
 package = wheel
 wheel_build_env = .pkg
+set_env =
+    NODE_VERSION=18.20.4
+    NPM_VERSION=10.9.0
 deps =
     pytest: -r requirements.txt
     eslint,stylelint: nodeenv

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,31 @@
 [tox]
 env_list =
-    node, eslint, stylelint, pylint, py312
+    pytest
+    pylint
+    eslint
+    stylelint
 minversion = 4.6.0
 skip_missing_interpreters = false
 
 [testenv]
-description = run the tests with pytest
+description = base environment
 package = wheel
 wheel_build_env = .pkg
 deps =
+    pytest: -r requirements.txt
+    eslint,stylelint: nodeenv
+commands_pre =
+    {es,style}lint: ./ci/node-install.sh
+allowlist_externals =
+    {es,style}lint: ./ci/node-install.sh
+
+[testenv:pytest]
+description = run the tests with pytest
+deps =
+    {[testenv]deps}
     pytest>=6
     pytest-mock>=3
-    -rrequirements.txt
-commands =
-    pytest {tty:--color=yes} {posargs}
+commands = pytest {tty:--color=yes} {posargs}
 
 [testenv:pylint]
 description = run python black linters
@@ -22,39 +34,12 @@ deps =
     black==24.8.0
 commands = black --check {posargs: ./tests ./dashboard}
 
-[testenv:node]
-description = setup Node.js environment
-skip_install = true
-deps =
-    nodeenv
-commands =
-    nodeenv --prebuilt -p --node 18.20.4
-    npm install -g npm@latest
-allowlist_externals =
-    node
-    npm
-    npx
-
 [testenv:eslint]
 description = run eslint
 skip_install = true
-deps =
-    {[testenv:node]deps}
-commands =
-    {[testenv:node]commands}
-    npm ci
-    npm run lint:js
-depends = node
-allowlist_externals = npm
+commands = npm run lint:js
 
 [testenv:stylelint]
 description = run stylelint
 skip_install = true
-deps =
-    {[testenv:node]deps}
-commands =
-    {[testenv:node]commands}
-    npm ci
-    npm run lint:css
-depends = node
-allowlist_externals = npm
+commands = npm run lint:css


### PR DESCRIPTION
(Sample size: 1)

Now (some output ommitted):

    # Do a clean build
    rm -rf .tox; time tox
    tox  17.25s user 8.84s system 49% cpu 52.303 total
    # Do a successive build
    time tox
    tox  1.72s user 0.38s system 86% cpu 2.436 total

Before (some output ommitted):

    # Do a clean build
    rm -rf .tox; time tox
    tox  19.69s user 11.41s system 46% cpu 1:06.32 total
    # Do a successive build
    time tox
    tox  3.57s user 3.64s system 24% cpu 29.537 total

It can go _faster_, but that'd come at the cost of having tox managing our dependencies when they change, so I opted not to do that. Though, we should keep that in our back pocket if we get to that point.