### PR TITLE
Swap Flask-KVSession for Flask-Session

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Faker==26.1.0
 filelock==3.15.4
 Flask==3.0.3
 Flask-Assets==2.1.0
-Flask-KVSession @ git+https://github.com/zacqed/flask-kvsession.git@83322aa18ed784bbe0cb309322e8d0d48bb762da
+Flask-Session==0.8.0
 Flask-pyoidc==3.14.3
 flask-talisman==1.1.0
 future==1.0.0
@@ -54,11 +54,10 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-jose==3.3.0
 PyYAML==6.0.1
-redis==5.0.8
+redis==5.2.0
 requests==2.32.3
 rsa==4.9
 setuptools==72.1.0
-simplekv==0.14.1
 six==1.16.0
 tox==4.16.0
 types-PyYAML==6.0.12.20240724

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 import os
 
 import dashboard.models.user as user
@@ -6,8 +7,8 @@ import dashboard.models.user as user
 
 class TestUser:
     def setup_method(self):
+        self.fixture_file = Path(__file__).parent.parent / "data" / "userinfo.json"
         try:
-            self.fixture_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data/userinfo.json")
             with open(self.fixture_file) as f:
                 self.session_fixture = json.load(f)
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ deps =
     types-colorama>=0.4
     types-pyasn1>=0.6
     types-python-jose>=3.3
-    types-redis>=4.6
     types-requests>=2.32
     types-six>=1.16
 commands = mypy {tty:--color-output:--no-color-output} {posargs: ./tests ./dashboard}


### PR DESCRIPTION
Note that upon deploying all sessions will invalidated since the keys (read as: keys in Redis) will change.

Jira: [IAM-1468](https://mozilla-hub.atlassian.net/browse/IAM-1468)