### PR TITLE
Be more explicit about configs and where they come from

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,10 +1,3 @@
-import os
-
-from everett.manager import ConfigManager  # type: ignore
-from everett.manager import ConfigOSEnv  # type: ignore
-
-# -*- coding: utf-8 -*-
-
 """Mozilla Single Signon Dashboard."""
 
 __author__ = """Andrew Krug"""
@@ -13,7 +6,3 @@ __version__ = "0.0.1"
 
 
 __all__ = ["app", "auth", "config", "models", "s3", "utils", "vanity"]
-
-
-def get_config():
-    return ConfigManager([ConfigOSEnv()])

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -162,6 +162,7 @@ def forbidden():
         tv = oidc_auth.TokenVerification(
             jws=request.args.get("error").encode(),
             public_key=app.config["FORBIDDEN_PAGE_PUBLIC_KEY"],
+            redirect_uri=oidc_config.OIDC_REDIRECT_URI,
         )
     except oidc_auth.TokenError:
         app.logger.exception("Could not validate JWS from IdP")

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -162,7 +162,6 @@ def forbidden():
         tv = oidc_auth.TokenVerification(
             jws=request.args.get("error").encode(),
             public_key=app.config["FORBIDDEN_PAGE_PUBLIC_KEY"],
-            redirect_uri=oidc_config.OIDC_REDIRECT_URI,
         )
     except oidc_auth.TokenError:
         app.logger.exception("Could not validate JWS from IdP")

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -57,9 +57,10 @@ class OIDC:
         self.OIDC_CLIENT_SECRET = os.environ["SSO-DASHBOARD_OIDC_CLIENT_SECRET"]
         # Check for a prefixed environment variable, otherwise fallback to the
         # unprefixed one.
-        self.OIDC_REDIRECT_URI = os.environ.get(
-            "SSO-DASHBOARD_OIDC_REDIRECT_URI", os.environ.get("OIDC_REDIRECT_URI", "https://sso.mozilla.com")
-        )
+        if redirect_uri := os.environ.get("SSO-DASHBOARD_OIDC_REDIRECT_URI"):
+            self.OIDC_REDIRECT_URI = redirect_uri
+        else:
+            self.OIDC_REDIRECT_URI = os.environ["OIDC_REDIRECT_URI"]
         self.LOGIN_URL = f"https://{self.OIDC_DOMAIN}/login?client={self.OIDC_CLIENT_ID}"
 
     @property

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,70 +1,54 @@
 """Configuration loader for different environments."""
 
+import os
 import base64
 import datetime
-from dashboard import get_config
-
-CONFIG = get_config()
 
 
-class Config(object):
-    def __init__(self, app):
-        self.app = app
-
-        self.environment = CONFIG("environment", default="local")
-        self.settings = self._init_env()
-
-    def _init_env(self):
-        return DefaultConfig()
-
-
-class DefaultConfig(object):
+class Default:
     """Defaults for the configuration objects."""
 
-    DEBUG = bool(CONFIG("debug", namespace="sso-dashboard", parser=bool, default="False"))
-    TESTING = bool(CONFIG("testing", namespace="sso-dashboard", parser=bool, default="False"))
+    ENVIRONMENT: str = os.environ.get("ENVIRONMENT", "local")
+    DEBUG: bool = os.environ.get("SSO-DASHBOARD_DEBUG", "True") == "True"
+    TESTING: bool = os.environ.get("SSO-DASHBOARD_TESTING", "True") == "True"
 
-    CSRF_ENABLED = bool(CONFIG("csrf_enabled", parser=bool, default="True"))
-    PERMANENT_SESSION = bool(CONFIG("permanent_session", namespace="sso-dashboard", parser=bool, default="True"))
-    seconds = int(CONFIG("permanent_session_lifetime", namespace="sso-dashboard", default="86400"))
-    PERMANENT_SESSION_LIFETIME = datetime.timedelta(seconds=seconds)
-
-    SESSION_COOKIE_SAMESITE = CONFIG("session_cookie_samesite", namespace="sso-dashboard", default="lax")
-    SESSION_COOKIE_HTTPONLY = bool(
-        CONFIG("session_cookie_httponly", namespace="sso-dashboard", parser=bool, default="True")
+    CSRF_ENABLED: bool = os.environ.get("SSO-DASHBOARD_CSRF_ENABLED", "True") == "True"
+    PERMANENT_SESSION: bool = os.environ.get("SSO-DASHBOARD_PERMANENT_SESSION", "True") == "True"
+    PERMANENT_SESSION_LIFETIME: datetime.timedelta = datetime.timedelta(
+        seconds=int(os.environ.get("SSO-DASHBOARD_PERMANENT_SESSION_LIFETIME", "86400"))
     )
 
-    SECRET_KEY = CONFIG("secret_key", namespace="sso-dashboard")
-    SERVER_NAME = CONFIG("server_name", namespace="sso-dashboard", default="localhost:8000")
-    SESSION_COOKIE_NAME = SERVER_NAME + "_session"
+    SESSION_COOKIE_SAMESITE: str = os.environ.get("SSO-DASHBOARD_SESSION_COOKIE_SAMESITE", "lax")
+    SESSION_COOKIE_HTTPONLY: bool = os.environ.get("SSO-DASHBOARD_SESSION_COOKIE_HTTPONLY", "True") == "True"
 
-    S3_BUCKET = CONFIG("s3_bucket", namespace="sso-dashboard")
+    SECRET_KEY: str = os.environ["SSO-DASHBOARD_SECRET_KEY"]
+    SERVER_NAME: str = os.environ.get("SSO-DASHBOARD_SERVER_NAME", "localhost:8000")
+    SESSION_COOKIE_NAME: str
+    CDN: str
 
-    CDN = CONFIG(
-        "cdn",
-        namespace="sso-dashboard",
-        default="https://cdn.{SERVER_NAME}".format(SERVER_NAME=SERVER_NAME),
-    )
+    S3_BUCKET: str = os.environ["SSO-DASHBOARD_S3_BUCKET"]
 
-    FORBIDDEN_PAGE_PUBLIC_KEY = base64.b64decode(CONFIG("forbidden_page_public_key", namespace="sso-dashboard"))
+    FORBIDDEN_PAGE_PUBLIC_KEY: bytes = base64.b64decode(os.environ["SSO-DASHBOARD_FORBIDDEN_PAGE_PUBLIC_KEY"])
 
-    PREFERRED_URL_SCHEME = CONFIG("preferred_url_scheme", namespace="sso-dashboard", default="https")
+    PREFERRED_URL_SCHEME: str = os.environ.get("SSO-DASHBOARD_PREFERRED_URL_SCHEME", "https")
+    REDIS_CONNECTOR: str = os.environ["SSO-DASHBOARD_REDIS_CONNECTOR"]
 
-    REDIS_CONNECTOR = CONFIG("redis_connector", namespace="sso-dashboard")
+    def __init__(self):
+        self.SESSION_COOKIE_NAME = f"{self.SERVER_NAME}_session"
+        self.CDN = os.environ.get("SSO-DASHBOARD_CDN", f"https://cdn.{self.SERVER_NAME}")
 
 
-class OIDCConfig(object):
+class OIDC:
     """Convienience Object for returning required vars to flask."""
+
+    OIDC_DOMAIN: str = os.environ["SSO-DASHBOARD_OIDC_DOMAIN"]
+    OIDC_CLIENT_ID: str = os.environ["SSO-DASHBOARD_OIDC_CLIENT_ID"]
+    OIDC_CLIENT_SECRET: str = os.environ["SSO-DASHBOARD_OIDC_CLIENT_SECRET"]
+    LOGIN_URL: str
 
     def __init__(self):
         """General object initializer."""
-        CONFIG = get_config()
-        self.OIDC_DOMAIN = CONFIG("oidc_domain", namespace="sso-dashboard")
-        self.OIDC_CLIENT_ID = CONFIG("oidc_client_id", namespace="sso-dashboard")
-        self.OIDC_CLIENT_SECRET = CONFIG("oidc_client_secret", namespace="sso-dashboard")
-        self.LOGIN_URL = "https://{DOMAIN}/login?client={CLIENT_ID}".format(
-            DOMAIN=self.OIDC_DOMAIN, CLIENT_ID=self.OIDC_CLIENT_ID
-        )
+        self.LOGIN_URL = f"https://{self.OIDC_DOMAIN}/login?client={self.OIDC_CLIENT_ID}"
 
     @property
     def client_id(self):
@@ -75,10 +59,10 @@ class OIDCConfig(object):
         return self.OIDC_CLIENT_SECRET
 
     def auth_endpoint(self):
-        return "https://{DOMAIN}/authorize".format(DOMAIN=self.OIDC_DOMAIN)
+        return f"https://{self.OIDC_DOMAIN}/authorize"
 
     def token_endpoint(self):
-        return "https://{DOMAIN}/oauth/token".format(DOMAIN=self.OIDC_DOMAIN)
+        return f"https://{self.OIDC_DOMAIN}/oauth/token"
 
     def userinfo_endpoint(self):
-        return "https://{DOMAIN}/userinfo".format(DOMAIN=self.OIDC_DOMAIN)
+        return f"https://{self.OIDC_DOMAIN}/userinfo"

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -21,33 +21,39 @@ class Default:
     SESSION_COOKIE_SAMESITE: str = os.environ.get("SSO-DASHBOARD_SESSION_COOKIE_SAMESITE", "lax")
     SESSION_COOKIE_HTTPONLY: bool = os.environ.get("SSO-DASHBOARD_SESSION_COOKIE_HTTPONLY", "True") == "True"
 
-    SECRET_KEY: str = os.environ["SSO-DASHBOARD_SECRET_KEY"]
+    SECRET_KEY: str
     SERVER_NAME: str = os.environ.get("SSO-DASHBOARD_SERVER_NAME", "localhost:8000")
     SESSION_COOKIE_NAME: str
     CDN: str
 
-    S3_BUCKET: str = os.environ["SSO-DASHBOARD_S3_BUCKET"]
-
-    FORBIDDEN_PAGE_PUBLIC_KEY: bytes = base64.b64decode(os.environ["SSO-DASHBOARD_FORBIDDEN_PAGE_PUBLIC_KEY"])
+    S3_BUCKET: str
+    FORBIDDEN_PAGE_PUBLIC_KEY: bytes
 
     PREFERRED_URL_SCHEME: str = os.environ.get("SSO-DASHBOARD_PREFERRED_URL_SCHEME", "https")
-    REDIS_CONNECTOR: str = os.environ["SSO-DASHBOARD_REDIS_CONNECTOR"]
+    REDIS_CONNECTOR: str
 
     def __init__(self):
         self.SESSION_COOKIE_NAME = f"{self.SERVER_NAME}_session"
         self.CDN = os.environ.get("SSO-DASHBOARD_CDN", f"https://cdn.{self.SERVER_NAME}")
+        self.REDIS_CONNECTOR = os.environ["SSO-DASHBOARD_REDIS_CONNECTOR"]
+        self.SECRET_KEY = os.environ["SSO-DASHBOARD_SECRET_KEY"]
+        self.S3_BUCKET = os.environ["SSO-DASHBOARD_S3_BUCKET"]
+        self.FORBIDDEN_PAGE_PUBLIC_KEY = base64.b64decode(os.environ["SSO-DASHBOARD_FORBIDDEN_PAGE_PUBLIC_KEY"])
 
 
 class OIDC:
     """Convienience Object for returning required vars to flask."""
 
-    OIDC_DOMAIN: str = os.environ["SSO-DASHBOARD_OIDC_DOMAIN"]
-    OIDC_CLIENT_ID: str = os.environ["SSO-DASHBOARD_OIDC_CLIENT_ID"]
-    OIDC_CLIENT_SECRET: str = os.environ["SSO-DASHBOARD_OIDC_CLIENT_SECRET"]
+    OIDC_DOMAIN: str
+    OIDC_CLIENT_ID: str
+    OIDC_CLIENT_SECRET: str
     LOGIN_URL: str
 
     def __init__(self):
         """General object initializer."""
+        self.OIDC_DOMAIN = os.environ["SSO-DASHBOARD_OIDC_DOMAIN"]
+        self.OIDC_CLIENT_ID = os.environ["SSO-DASHBOARD_OIDC_CLIENT_ID"]
+        self.OIDC_CLIENT_SECRET = os.environ["SSO-DASHBOARD_OIDC_CLIENT_SECRET"]
         self.LOGIN_URL = f"https://{self.OIDC_DOMAIN}/login?client={self.OIDC_CLIENT_ID}"
 
     @property

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -47,6 +47,7 @@ class OIDC:
     OIDC_DOMAIN: str
     OIDC_CLIENT_ID: str
     OIDC_CLIENT_SECRET: str
+    OIDC_REDIRECT_URI: str
     LOGIN_URL: str
 
     def __init__(self):
@@ -54,6 +55,11 @@ class OIDC:
         self.OIDC_DOMAIN = os.environ["SSO-DASHBOARD_OIDC_DOMAIN"]
         self.OIDC_CLIENT_ID = os.environ["SSO-DASHBOARD_OIDC_CLIENT_ID"]
         self.OIDC_CLIENT_SECRET = os.environ["SSO-DASHBOARD_OIDC_CLIENT_SECRET"]
+        # Check for a prefixed environment variable, otherwise fallback to the
+        # unprefixed one.
+        self.OIDC_REDIRECT_URI = os.environ.get(
+            "SSO-DASHBOARD_OIDC_REDIRECT_URI", os.environ.get("OIDC_REDIRECT_URI", "https://sso.mozilla.com")
+        )
         self.LOGIN_URL = f"https://{self.OIDC_DOMAIN}/login?client={self.OIDC_CLIENT_ID}"
 
     @property

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -57,12 +57,3 @@ class OIDC:
     @property
     def client_secret(self):
         return self.OIDC_CLIENT_SECRET
-
-    def auth_endpoint(self):
-        return f"https://{self.OIDC_DOMAIN}/authorize"
-
-    def token_endpoint(self):
-        return f"https://{self.OIDC_DOMAIN}/oauth/token"
-
-    def userinfo_endpoint(self):
-        return f"https://{self.OIDC_DOMAIN}/userinfo"

--- a/dashboard/oidc_auth.py
+++ b/dashboard/oidc_auth.py
@@ -65,7 +65,10 @@ class TokenError(BaseException):
 
 
 class TokenVerification:
-    def __init__(self, jws, public_key):
+    oidc_redirect_uri: str
+
+    def __init__(self, jws, public_key, redirect_uri: str):
+        self.oidc_redirect_uri = redirect_uri
         try:
             self.jws = JWS.from_compact(jws)
         except josepy.errors.DeserializationError as exc:
@@ -104,7 +107,7 @@ class TokenVerification:
 
     @property
     def redirect_uri(self) -> str:
-        return self.jws_data.get("redirect_uri", "https://sso.mozilla.com")
+        return self.jws_data.get("redirect_uri", self.oidc_redirect_uri)
 
     def signed(self) -> bool:
         """

--- a/dashboard/oidc_auth.py
+++ b/dashboard/oidc_auth.py
@@ -65,10 +65,7 @@ class TokenError(BaseException):
 
 
 class TokenVerification:
-    oidc_redirect_uri: str
-
-    def __init__(self, jws, public_key, redirect_uri: str):
-        self.oidc_redirect_uri = redirect_uri
+    def __init__(self, jws, public_key):
         try:
             self.jws = JWS.from_compact(jws)
         except josepy.errors.DeserializationError as exc:
@@ -104,10 +101,6 @@ class TokenVerification:
     @property
     def preferred_connection_name(self) -> Optional[str]:
         return self.jws_data.get("preferred_connection_name")
-
-    @property
-    def redirect_uri(self) -> str:
-        return self.jws_data.get("redirect_uri", self.oidc_redirect_uri)
 
     def signed(self) -> bool:
         """

--- a/env.example
+++ b/env.example
@@ -1,20 +1,49 @@
 ### This file is a sample environment file for use with the project.
+# To see these in action see the `clouddeploy` directory.
 
 # This should be random in production deployment used in session security.
-SECRET_KEY="this is a secret key"
+# Easy way to generate:
+# openssl rand -hex 64
+SSO-DASHBOARD_SECRET_KEY="this is a secret key"
 
-# Development or production.
-ENVIRONMENT="Development"
+# local, development, staging, or production.
+ENVIRONMENT="local"
 
 # OpenID Connect Specific Parameters
-OIDC_DOMAIN="auth0.example.com"
-OIDC_CLIENT_ID=""
-OIDC_CLIENT_SECRET=""
+# We use Auth0, the configs for this would be under the Application "Settings"
+# page.
+SSO-DASHBOARD_OIDC_DOMAIN="auth0.example.com"
+SSO-DASHBOARD_OIDC_CLIENT_ID=""
+SSO-DASHBOARD_OIDC_CLIENT_SECRET=""
 
-# User avatar parameters
-MOZILLIANS_API_URL='https://mozillians.org/api/v2/users/'
-MOZILLIANS_API_KEY=''
+# Yes, this one is not namespaced.
+# DEBT(bhee): standardize at some point.
+OIDC_REDIRECT_URI='https://localhost.localdomain:8000/redirect_uri'
 
-SERVER_NAME="localhost:5000"
-PERMANENT_SESSION=True
-PERMANENT_SESSION_LIFETIME=900
+# Controls the logging levels
+SSO-DASHBOARD_DEBUG=True
+
+# Unused right now.
+SSO-DASHBOARD_TESTING=False
+
+# Reasonable for local development, you'll want to change these in production
+# though.
+SSO-DASHBOARD_CSRF_ENABLED=True
+SSO-DASHBOARD_PERMANENT_SESSION=True
+SSO-DASHBOARD_PERMANENT_SESSION_LIFETIME=86400
+SSO-DASHBOARD_SESSION_COOKIE_HTTPONLY=True
+SSO-DASHBOARD_SERVER_NAME=localhost.localdomain:8000
+SSO-DASHBOARD_PREFERRED_URL_SCHEME=http
+
+# You'll need a running redis.
+# See compose.yml.
+SSO-DASHBOARD_REDIS_CONNECTOR=redis:6379
+
+# Where we publish the `apps.yml` file.
+SSO-DASHBOARD_CDN=https://cdn.sso.mozilla.com
+SSO-DASHBOARD_S3_BUCKET=sso-dashboard.configuration
+
+# Used to decode the JWS from Auth0 (e.g. for if we redirect back and there's some
+# context Auth0 passes us, like the error code.)
+# Base64 + PEM encoded.
+SSO-DASHBOARD_FORBIDDEN_PAGE_PUBLIC_KEY=""

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ cryptography==43.0.1
 cssmin==0.2.0
 defusedxml==0.7.1
 distlib==0.3.8
-everett==3.3.0
 Faker==26.1.0
 filelock==3.15.4
 Flask==3.0.3

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -19,7 +19,6 @@ class TestValidOidcAuth:
         tv = oidc_auth.TokenVerification(
             jws=self.sample_json_web_token.encode(),
             public_key=self.public_key.encode(),
-            redirect_uri="http://test",
         )
         assert tv.signed(), "Could not verify JWS"
 
@@ -27,7 +26,6 @@ class TestValidOidcAuth:
 class TestInvalidOidcAuth:
     def setup_method(self):
         keypair = ec.generate_private_key(ec.SECP256R1())
-        self.redirect_uri = "http://test"
         self.private_key = JWK.load(
             keypair.private_bytes(
                 Encoding.PEM,
@@ -45,7 +43,7 @@ class TestInvalidOidcAuth:
             alg=ES256,
         )
         with pytest.raises(oidc_auth.TokenError):
-            oidc_auth.TokenVerification(jws.to_compact(), self.public_key, self.redirect_uri)
+            oidc_auth.TokenVerification(jws.to_compact(), self.public_key)
 
     def test_empty_json_body(self):
         jws = JWS.sign(
@@ -54,7 +52,7 @@ class TestInvalidOidcAuth:
             payload=json.dumps({}).encode("utf-8"),
             protect={"alg"},
         ).to_compact()
-        tv = oidc_auth.TokenVerification(jws, self.public_key, self.redirect_uri)
+        tv = oidc_auth.TokenVerification(jws, self.public_key)
         assert tv.signed(), "should have been signed"
         # These don't super matter a whole lot, just checking that we don't
         # accidentally throw assertions.
@@ -73,5 +71,5 @@ class TestInvalidOidcAuth:
                 ).encode("utf-8"),
                 protect={"alg"},
             ).to_compact()
-            tv = oidc_auth.TokenVerification(jws, self.public_key, self.redirect_uri)
+            tv = oidc_auth.TokenVerification(jws, self.public_key)
             assert tv.error_message() is not None, f"couldn't generate message for {error_code}"


### PR DESCRIPTION
This PR adds/removes a couple of things:

* A documented `env.sample`
* An _updated_ `env.sample`, now shows the full keys we expect, along with some docs about where to get them
* Less dependencies (`everett`) -- this one did a bit of magic which I removed and implemented ourself (as a result it should be _painfully_ clear what's missing on startup)
* Use `OIDC_REDIRECT_URI` -- we set this environment variable but never use it

See individual commits for a better review story.