### PR TITLE
Support RP-Initiated logout, further removing the need for NLX

### DIFF
--- a/dashboard/templates/forbidden.html
+++ b/dashboard/templates/forbidden.html
@@ -22,7 +22,7 @@
 
   <div class="mui-row section">
     <div class="mui-col-md-6 mui-col-md-offset-3">
-      <a href="https://sso.mozilla.com/logout" class="mui-btn help">Logout</a>
+      <a href="/logout" class="mui-btn help">Logout</a>
       <a href="https://discourse.mozilla.org/c/iam" class="mui-btn help">Need Help?</a>
       <a href="/dashboard" class="mui-btn return">Return to dashboard</a>
     </div>

--- a/dashboard/templates/signout.html
+++ b/dashboard/templates/signout.html
@@ -18,7 +18,7 @@
       </h2>
         <p>Make sure you also log out of each individual application used this session.</p>
         <hr>
-        <a href="https://sso.mozilla.com" class="button button--secondary">Log in to Mozilla</a>
+        <a href="/" class="button button--secondary">Log in to Mozilla</a>
       <ul class="legal-links list list--plain">
         <li><a href="https://www.mozilla.org/en-US/about/legal/" target="_blank">Legal</a></li>
         <li><a href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank">Privacy</a></li>


### PR DESCRIPTION
Flask-pyoidc supports provider discovery which we can make use of for auto-enabling the RP-Initiated Logout End Session Endpoint Discovery feature set.

When enabled the logout flow changes a bit and does not require a redirect in NLX, instead depending directly on Auth0 to complete the OIDC ceremony.

Prerequisites:

* `/logout` URL added as an accepted logout URL in the _client_ settings;
* RP-Initiated Logout End Session Endpoint Discovery enabled in _tenant_ settings;
    * Toggling this in Auth0 _will require that you restart the application_.

Jira: [IAM-1493](https://mozilla-hub.atlassian.net/browse/IAM-1493)