### PR TITLE
Body font tweak: deletes letter spacing, drops font size 2px

### DIFF
--- a/dashboard/static/css/base.scss
+++ b/dashboard/static/css/base.scss
@@ -50,10 +50,9 @@ body {
     color: $gray;
     padding: 0;
     margin: 0;
-    font-size: 16px;
+    font-size: 14px;
     line-height: 1.4;
     font-family: 'Open Sans', sans-serif;
-    letter-spacing: 0.03em;
 }
 
 .visually-hidden {


### PR DESCRIPTION
I think this makes for a slightly more readable dashboard, mostly by dropping the letter spacing which bugs my eyes. But obviously, just a suggestion.

Before:
<img width="1021" alt="before" src="https://github.com/user-attachments/assets/d44ffec5-2b1f-4eac-93a9-021380fa1a93" />

After:
<img width="1020" alt="after" src="https://github.com/user-attachments/assets/261594c6-d30e-4201-b781-f6a3ab9f5260" />
