### PR TITLE
Do not force new tab for all external links

### DIFF
--- a/dashboard/static/js/base.js
+++ b/dashboard/static/js/base.js
@@ -29,7 +29,7 @@ $(document).ready(function(){
                 const tiles = $('#app-grid .app-tile:visible');
                 if (tiles.length === 1) {
                 // If only one tile is visible, open its link on Enter
-                    window.open(tiles[0].href, '_blank');
+                    window.open(tiles[0].href);
                 }
             }
         });

--- a/dashboard/templates/dashboard.html
+++ b/dashboard/templates/dashboard.html
@@ -57,7 +57,7 @@
 
 {% block user_menu %}
   <div class="user-menu">
-    <a href="https://people.mozilla.org/e" target="_blank"><span>Settings</span> <img class="menu-icon" src="/static/img/settings.svg" alt=""></a>
+    <a href="https://people.mozilla.org/e"><span>Settings</span> <img class="menu-icon" src="/static/img/settings.svg" alt=""></a>
     <a href="/logout"><span>Logout</span> <img class="menu-icon"src="/static/img/logout.svg" alt=""></a>
     <a href="/autologin-settings"><span>Enable / Disable Auto-login</span></a>
   </div>
@@ -68,7 +68,7 @@
     <ul>
     {% for app in apps %}
       <li>
-        <a href="{{ app['application']['url'] }}" data-id="{{ app['application']['name'] }}" class="app-tile" target="_blank">
+        <a href="{{ app['application']['url'] }}" data-id="{{ app['application']['name'] }}" class="app-tile">
           <div class="mui--text-center app-logo">
             <img src="{{ config.CDN }}/images/{{ app['application']['logo'] }}" role="presentation" alt="">
           </div>

--- a/dashboard/templates/layout.html
+++ b/dashboard/templates/layout.html
@@ -54,31 +54,31 @@
           <div class="icon-container">
             <div class="icon">
               <img class="footer-icon" src="/static/img/email.svg">
-              <a target="_blank" href="https://mozilla-hub.atlassian.net/servicedesk/customer/portal/4/group/36/create/213" target="_blank">Need Help?</a>
+              <a href="https://mozilla-hub.atlassian.net/servicedesk/customer/portal/4/group/36/create/213">Need Help?</a>
             </div>
           </div>
           <div class="icon-container">
             <div class="icon">
               <img class="footer-icon" src="/static/img/feedback.svg">
-              <a target="_blank" href="https://discourse.mozilla.org/c/iam/dashboard" target="_blank">Feedback</a>
+              <a href="https://discourse.mozilla.org/c/iam/dashboard">Feedback</a>
             </div>
           </div>
           <div class="icon-container">
             <div class="icon">
               <img class="footer-icon" src="/static/img/github.svg">
-              <a target="_blank" href="https://github.com/mozilla-iam/sso-dashboard" target="_blank">Contribute</a>
+              <a href="https://github.com/mozilla-iam/sso-dashboard">Contribute</a>
             </div>
           </div>
           <div class="icon-container">
             <div class="icon">
               <img class="footer-icon" src="/static/img/legal.svg">
-              <a target="_blank" href="https://www.mozilla.org/en-US/about/legal/" target="_blank">Legal</a>
+              <a href="https://www.mozilla.org/en-US/about/legal/">Legal</a>
             </div>
           </div>
           <div class="icon-container">
             <div class="icon">
               <img class="footer-icon" src="/static/img/privacy.svg">
-              <a target="_blank" href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank">Privacy</a>
+              <a href="https://www.mozilla.org/en-US/privacy/websites/">Privacy</a>
             </div>
           </div>
         </div>

--- a/dashboard/templates/signout.html
+++ b/dashboard/templates/signout.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div class="card">
-      <a href="https://mozilla.org" class="logo" target="_blank">
+      <a href="https://mozilla.org" class="logo">
         <img src="/static/img/mozilla.svg" alt="mozilla">
       </a>
 
@@ -20,9 +20,9 @@
         <hr>
         <a href="/" class="button button--secondary">Log in to Mozilla</a>
       <ul class="legal-links list list--plain">
-        <li><a href="https://www.mozilla.org/en-US/about/legal/" target="_blank">Legal</a></li>
-        <li><a href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank">Privacy</a></li>
-        <li><a href="https://discourse.mozilla.org/c/iam" target="_blank">Need help?</a></li>
+        <li><a href="https://www.mozilla.org/en-US/about/legal/">Legal</a></li>
+        <li><a href="https://www.mozilla.org/en-US/privacy/websites/">Privacy</a></li>
+        <li><a href="https://discourse.mozilla.org/c/iam">Need help?</a></li>
       </ul>
     </div>
   </body>


### PR DESCRIPTION
At least in my use of sso.mozilla.com, the page loads quite quickly, and I almost always use it to open a single app. In this usage pattern, having the `target="_blank"` on each app link open a new tab adds an extra, unnecessary step of closing the SSO dashboard tab.

Hence this PR's proposed change of dropping that, and relying on the usual Ctrl/Cmd+click functionality of opening a link in a new tab.