### PR TITLE
fix(styleguide): remove broken notifications route

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -262,16 +262,7 @@ def styleguide_dashboard():
     return render_template("dashboard.html", config=app.config, user=user, apps=apps)
 
 
-@app.route("/styleguide/notifications")
-@oidc.oidc_auth("default")
-def styleguide_notifications():
-    user = FakeUser(app.config)
-    return render_template("notifications.html", config=app.config, user=user)
-
-
-"""useful endpoint for debugging"""
-
-
+# useful endpoint for debugging
 @app.route("/info")
 @oidc.oidc_auth("default")
 def info():


### PR DESCRIPTION
## What changed

Removes the unused `/styleguide/notifications` Flask route from `dashboard/app.py`. The route rendered a `notifications.html` template that does not exist under `dashboard/templates/`, so any request to it raised a 500. While here, the floating string `"""useful endpoint for debugging"""` between functions is converted to a real `#` comment. It was a no-op statement, not a docstring.

## Why

Dead code. Nothing links to the route, and the template it referenced was never created. There is a `.notifications` CSS block in `dashboard/static/css/base.scss` suggesting this was started and abandoned, but there is no in-flight notifications feature to support. The sibling styleguide route `/styleguide/dashboard` is the actual styleguide entry point and is untouched.

## Blast radius

Minimal. The route was effectively unreachable: not linked from any template or navigation, and any direct visitor (e.g. a stale bookmark) was already hitting a 500. The only behavior change is that the response code becomes a 404 instead of a 500. `FakeUser` remains in use via `/styleguide/dashboard`.

## Cross-repo coordination

None. No schema, contract, or `apps.yml` format changes.

## Test plan

- `tox` passes locally (lint + types + tests + style).
- No browser verification required: this is a deletion of an unreachable code path.
- `grep` across the repo confirms no other file references `styleguide_notifications` or `notifications.html`.

## Caveats

The `.notifications` CSS block remains in `static/css/base.scss`. Cheap to leave; if a notifications feature ever comes back the CSS is there to build against, and if not it can be removed in a separate cleanup PR.